### PR TITLE
feat: 투표(Vote) SDUI 기능 추가

### DIFF
--- a/docs/sql/vote_feature.sql
+++ b/docs/sql/vote_feature.sql
@@ -1,0 +1,93 @@
+-- =====================================================================
+-- Vote(투표) 기능 첫 배포용 수동 DDL (MySQL 8)
+-- =====================================================================
+-- 이 프로젝트는 spring.jpa.hibernate.ddl-auto=update 이며 Flyway/Liquibase 가 없다.
+-- update 모드는 "새 테이블"은 제약과 함께 생성하지만, "이미 존재하는 테이블"에는
+-- 제약 추가/컬럼 타입 변경을 신뢰성 있게 반영하지 못한다.
+-- 따라서 운영 배포 시 ddl-auto 에 의존하지 말고 본 스크립트를 먼저 1회 실행할 것을 권장한다.
+-- (특히 vote_response 의 유니크 제약, team.service_name 컬럼 추가)
+-- =====================================================================
+
+-- 0) 기존 team 테이블에 서비스명 컬럼 추가 (nullable -> update 모드에서도 안전하지만 명시 실행 권장)
+ALTER TABLE team
+    ADD COLUMN service_name VARCHAR(100) NULL COMMENT '서비스명 (투표 화면 표기용)';
+
+-- 1) 투표 (라이프사이클/상태/기수 소유, 두 관심사의 템플릿 보유)
+CREATE TABLE vote (
+    id                BIGINT       NOT NULL AUTO_INCREMENT,
+    generation_id     BIGINT       NOT NULL COMMENT '기수 Id',
+    title             VARCHAR(100) NOT NULL COMMENT '투표 제목',
+    status            VARCHAR(20)  NOT NULL COMMENT '투표 상태 (DRAFT/OPEN/CLOSED)',
+    template_version  INT          NOT NULL COMMENT '템플릿 버전',
+    team_vote_template TEXT        NULL COMMENT '팀 투표 템플릿 (JSON)',
+    feedback_template  TEXT        NULL COMMENT '참여 경험 피드백 템플릿 (JSON)',
+    opened_at         DATETIME     NULL COMMENT '투표 시작 시각',
+    closed_at         DATETIME     NULL COMMENT '투표 종료 시각',
+    created_date      DATETIME     NOT NULL COMMENT '생성 일자',
+    created_id        BIGINT       NOT NULL COMMENT '생성자',
+    updated_date      DATETIME     NULL COMMENT '수정 일자',
+    updated_id        BIGINT       NULL COMMENT '수정자',
+    PRIMARY KEY (id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+-- 2) 투표 응답 (투표당 1인 1응답 - 유니크 제약으로 멱등 보장)
+CREATE TABLE vote_response (
+    id                     BIGINT NOT NULL AUTO_INCREMENT,
+    vote_id                BIGINT NOT NULL COMMENT '투표 Id',
+    member_id              BIGINT NOT NULL COMMENT '응답한 멤버 Id',
+    template_version       INT    NOT NULL COMMENT '응답 시점 템플릿 버전',
+    snapshot_team_id       BIGINT NULL COMMENT '제출 시점 소속 팀 Id 스냅샷',
+    snapshot_generation_id BIGINT NULL COMMENT '제출 시점 소속 기수 Id 스냅샷',
+    created_date           DATETIME NOT NULL COMMENT '생성 일자',
+    created_id             BIGINT   NOT NULL COMMENT '생성자',
+    updated_date           DATETIME NULL COMMENT '수정 일자',
+    updated_id             BIGINT   NULL COMMENT '수정자',
+    PRIMARY KEY (id),
+    CONSTRAINT uk_vote_response_vote_member UNIQUE (vote_id, member_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+-- 3) 팀 투표 선택 (부문별 선택 팀, 집계용 정규화 행)
+CREATE TABLE team_vote_answer (
+    id           BIGINT       NOT NULL AUTO_INCREMENT,
+    response_id  BIGINT       NOT NULL COMMENT '응답 Id',
+    category_id  VARCHAR(100) NOT NULL COMMENT '부문 ID(템플릿 안정 시맨틱 ID)',
+    team_id      BIGINT       NOT NULL COMMENT '선택한 팀 Id',
+    created_date DATETIME     NOT NULL COMMENT '생성 일자',
+    created_id   BIGINT       NOT NULL COMMENT '생성자',
+    updated_date DATETIME     NULL COMMENT '수정 일자',
+    updated_id   BIGINT       NULL COMMENT '수정자',
+    PRIMARY KEY (id),
+    KEY idx_team_vote_answer_response (response_id),
+    KEY idx_team_vote_answer_category_team (category_id, team_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+-- 4) 팀 투표 부문별 작성 사유
+CREATE TABLE team_vote_reason (
+    id           BIGINT       NOT NULL AUTO_INCREMENT,
+    response_id  BIGINT       NOT NULL COMMENT '응답 Id',
+    category_id  VARCHAR(100) NOT NULL COMMENT '부문 ID(템플릿 안정 시맨틱 ID)',
+    reason       VARCHAR(500) NULL COMMENT '작성 사유',
+    created_date DATETIME     NOT NULL COMMENT '생성 일자',
+    created_id   BIGINT       NOT NULL COMMENT '생성자',
+    updated_date DATETIME     NULL COMMENT '수정 일자',
+    updated_id   BIGINT       NULL COMMENT '수정자',
+    PRIMARY KEY (id),
+    KEY idx_team_vote_reason_response (response_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+-- 5) 피드백 응답 (질문 타입별로 option_id / text_value / bool_value 중 하나가 채워짐)
+CREATE TABLE feedback_answer (
+    id           BIGINT       NOT NULL AUTO_INCREMENT,
+    response_id  BIGINT       NOT NULL COMMENT '응답 Id',
+    question_id  VARCHAR(100) NOT NULL COMMENT '질문 ID(템플릿 안정 시맨틱 ID)',
+    option_id    VARCHAR(100) NULL COMMENT '선택지 ID(MULTI_SELECT)',
+    text_value   VARCHAR(500) NULL COMMENT '텍스트 응답(LONG_TEXT)',
+    bool_value   BIT(1)       NULL COMMENT '예/아니오 응답(BOOLEAN)',
+    created_date DATETIME     NOT NULL COMMENT '생성 일자',
+    created_id   BIGINT       NOT NULL COMMENT '생성자',
+    updated_date DATETIME     NULL COMMENT '수정 일자',
+    updated_id   BIGINT       NULL COMMENT '수정자',
+    PRIMARY KEY (id),
+    KEY idx_feedback_answer_response (response_id),
+    KEY idx_feedback_answer_question_option (question_id, option_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;

--- a/src/main/java/com/ddd/manage_attendance/core/config/jpa/JpaConfig.java
+++ b/src/main/java/com/ddd/manage_attendance/core/config/jpa/JpaConfig.java
@@ -5,15 +5,29 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 @Configuration
 @EnableJpaAuditing
 class JpaConfig {
 
+    // 인증 컨텍스트가 없는 경우(OAuth 가입 등 시스템 작업)에 사용하는 감사자 ID
+    private static final Long SYSTEM_AUDITOR = 0L;
+
     @Bean
     public AuditorAware<Long> auditorProvider() {
-        // OAuth 로그인 시 시스템 사용자 ID를 반환
-        // TODO: 실제 인증된 사용자 ID를 반환하도록 수정 필요
-        return () -> Optional.of(0L);
+        return () -> {
+            final Authentication authentication =
+                    SecurityContextHolder.getContext().getAuthentication();
+            if (authentication == null || !authentication.isAuthenticated()) {
+                return Optional.of(SYSTEM_AUDITOR);
+            }
+            // JwtAuthenticationFilter 가 principal 로 Long userId 를 설정한다.
+            if (authentication.getPrincipal() instanceof Long userId) {
+                return Optional.of(userId);
+            }
+            return Optional.of(SYSTEM_AUDITOR);
+        };
     }
 }

--- a/src/main/java/com/ddd/manage_attendance/core/exception/ErrorCode.java
+++ b/src/main/java/com/ddd/manage_attendance/core/exception/ErrorCode.java
@@ -29,6 +29,15 @@ public enum ErrorCode {
     // 팀 관련
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 팀입니다."),
 
+    // 투표 관련
+    VOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 투표입니다."),
+    VOTE_NOT_DRAFT(HttpStatus.BAD_REQUEST, "작성중(DRAFT) 상태에서만 수정할 수 있습니다."),
+    VOTE_NOT_OPEN(HttpStatus.BAD_REQUEST, "진행중(OPEN)인 투표가 아닙니다."),
+    VOTE_INVALID_STATUS(HttpStatus.BAD_REQUEST, "현재 투표 상태에서는 수행할 수 없는 작업입니다."),
+    VOTE_OWN_TEAM_SELECTED(HttpStatus.BAD_REQUEST, "본인 팀은 투표할 수 없습니다."),
+    VOTE_ANSWER_INVALID(HttpStatus.BAD_REQUEST, "투표 응답이 제약 조건을 위반했습니다."),
+    VOTE_ALREADY_RESPONDED(HttpStatus.BAD_REQUEST, "이미 투표에 참여했습니다."),
+
     // 데이터 관련
     DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 데이터입니다."),
 

--- a/src/main/java/com/ddd/manage_attendance/core/sdui/FeedbackTemplate.java
+++ b/src/main/java/com/ddd/manage_attendance/core/sdui/FeedbackTemplate.java
@@ -1,0 +1,32 @@
+package com.ddd.manage_attendance.core.sdui;
+
+import java.util.List;
+
+/**
+ * 2단계 "참여 경험 피드백" 템플릿 정의(불변 스냅샷).
+ *
+ * <p>{@link Question} 은 {@link VoteComponentType} 에 따라 해석된다.
+ *
+ * <ul>
+ *   <li>MULTI_SELECT — {@code options} 중 다중 선택, {@code maxSelectableOptions}(null=무제한), 선택적 {@code
+ *       followUp} 후속 질문
+ *   <li>LONG_TEXT — {@code maxLength} 제한 텍스트
+ *   <li>BOOLEAN — 예/아니오
+ * </ul>
+ */
+public record FeedbackTemplate(String title, String description, List<Question> questions) {
+
+    public record Question(
+            String id,
+            int order,
+            VoteComponentType type,
+            String title,
+            String helpText,
+            boolean required,
+            Integer maxSelectableOptions,
+            Integer maxLength,
+            List<Option> options,
+            Question followUp) {}
+
+    public record Option(String id, String label) {}
+}

--- a/src/main/java/com/ddd/manage_attendance/core/sdui/TeamVoteTemplate.java
+++ b/src/main/java/com/ddd/manage_attendance/core/sdui/TeamVoteTemplate.java
@@ -1,0 +1,23 @@
+package com.ddd.manage_attendance.core.sdui;
+
+import java.util.List;
+
+/**
+ * 1단계 "팀 투표" 템플릿 정의(불변 스냅샷). Vote 엔티티에 text 컬럼으로 직렬화되어 저장되며, 버전 고정의 단위가 된다.
+ *
+ * <p>각 {@link Category} 는 안정 시맨틱 ID 를 가지며, 라벨/순서가 바뀌어도 ID 로 집계가 유지된다.
+ */
+public record TeamVoteTemplate(
+        String title, String description, String notice, List<Category> categories) {
+
+    /** 투표 부문(예: 기획 완성도 / 디자인 / 개발 완성도). */
+    public record Category(
+            String id,
+            int order,
+            String title,
+            int maxSelectableTeams,
+            boolean reasonRequired,
+            int reasonMinLength,
+            int reasonMaxLength,
+            String reasonLabel) {}
+}

--- a/src/main/java/com/ddd/manage_attendance/core/sdui/VoteComponentType.java
+++ b/src/main/java/com/ddd/manage_attendance/core/sdui/VoteComponentType.java
@@ -1,0 +1,20 @@
+package com.ddd.manage_attendance.core.sdui;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * SDUI(Server-Driven UI) 컴포넌트 타입.
+ *
+ * <p>서버는 질문의 "의미 타입"만 내려주고, 실제 렌더링은 클라이언트가 소유한다. 새로운 타입 추가만 앱 배포가 필요하며 텍스트/옵션/순서/제약은 서버에서 변경한다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum VoteComponentType {
+    TEAM_SELECT("팀 선택"),
+    MULTI_SELECT("다중 선택"),
+    LONG_TEXT("장문 텍스트"),
+    BOOLEAN("예/아니오");
+
+    private final String description;
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/team/api/dto/TeamResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/team/api/dto/TeamResponse.java
@@ -7,10 +7,11 @@ import java.util.stream.Collectors;
 
 public record TeamResponse(
         @Schema(description = "팀 Id", example = "1") Long teamId,
-        @Schema(description = "팀 이름", example = "web1팀") String name) {
+        @Schema(description = "팀 이름", example = "web1팀") String name,
+        @Schema(description = "서비스명", example = "디톡스메이트") String serviceName) {
 
     public static TeamResponse from(final Team team) {
-        return new TeamResponse(team.getId(), team.getName());
+        return new TeamResponse(team.getId(), team.getName(), team.getServiceName());
     }
 
     public static List<TeamResponse> fromList(final List<Team> teams) {

--- a/src/main/java/com/ddd/manage_attendance/domain/team/domain/Team.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/team/domain/Team.java
@@ -41,13 +41,30 @@ public class Team extends BaseEntity {
     @Column(name = "generation_id", columnDefinition = "bigint")
     private Long generationId;
 
+    @Comment("서비스명 (팀이 만든 서비스 이름, 투표 화면 표기용)")
+    @Column(name = "service_name", nullable = true, columnDefinition = "varchar(100)")
+    private String serviceName;
+
     @Builder(access = AccessLevel.PRIVATE)
-    public Team(String name, Long generationId) {
+    public Team(String name, Long generationId, String serviceName) {
         this.name = name;
         this.generationId = generationId;
+        this.serviceName = serviceName;
     }
 
     public static Team createTeam(String name, Long generationId) {
-        return Team.builder().name(name).generationId(generationId).build();
+        return createTeam(name, generationId, null);
+    }
+
+    public static Team createTeam(String name, Long generationId, String serviceName) {
+        return Team.builder()
+                .name(name)
+                .generationId(generationId)
+                .serviceName(serviceName)
+                .build();
+    }
+
+    public void updateServiceName(final String serviceName) {
+        this.serviceName = serviceName;
     }
 }

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/VoteController.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/VoteController.java
@@ -1,0 +1,112 @@
+package com.ddd.manage_attendance.domain.vote.api;
+
+import com.ddd.manage_attendance.domain.vote.api.dto.FeedbackTemplateResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.TeamVoteTemplateResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteCreateRequest;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteCreateResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteTemplateUpdateRequest;
+import com.ddd.manage_attendance.domain.vote.domain.VoteFacade;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/votes")
+@RequiredArgsConstructor
+@Tag(name = "Vote", description = "투표(팀 투표 / 참여 경험 피드백) API")
+public class VoteController {
+
+    private final VoteFacade voteFacade;
+
+    @PostMapping
+    @Operation(
+            summary = "[운영진] 투표 생성",
+            description = "팀 투표 / 피드백 템플릿을 가진 투표를 DRAFT 상태로 생성합니다.\n\n- 운영진 권한 필수")
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<VoteCreateResponse> createVote(
+            @AuthenticationPrincipal final Long userId,
+            @RequestBody final VoteCreateRequest request) {
+        final Long voteId = voteFacade.createVote(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(VoteCreateResponse.from(voteId));
+    }
+
+    @PutMapping("/{voteId}/template")
+    @Operation(
+            summary = "[운영진] 투표 템플릿 수정",
+            description = "DRAFT 상태에서만 템플릿을 수정합니다. 수정 시 템플릿 버전이 증가합니다.\n\n- 운영진 권한 필수")
+    @SecurityRequirement(name = "JWT")
+    public void updateTemplate(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long voteId,
+            @RequestBody final VoteTemplateUpdateRequest request) {
+        voteFacade.updateTemplate(userId, voteId, request);
+    }
+
+    @PatchMapping("/{voteId}/open")
+    @Operation(
+            summary = "[운영진] 투표 시작",
+            description = "투표를 OPEN 상태로 전환합니다(템플릿 freeze).\n\n- 운영진 권한 필수\n- DRAFT 상태에서만 가능")
+    @SecurityRequirement(name = "JWT")
+    public void openVote(
+            @AuthenticationPrincipal final Long userId, @PathVariable final Long voteId) {
+        voteFacade.openVote(userId, voteId);
+    }
+
+    @PatchMapping("/{voteId}/close")
+    @Operation(
+            summary = "[운영진] 투표 종료",
+            description = "투표를 CLOSED 상태로 전환합니다(불가역).\n\n- 운영진 권한 필수\n- OPEN 상태에서만 가능")
+    @SecurityRequirement(name = "JWT")
+    public void closeVote(
+            @AuthenticationPrincipal final Long userId, @PathVariable final Long voteId) {
+        voteFacade.closeVote(userId, voteId);
+    }
+
+    @GetMapping("/{voteId}/team-vote/template")
+    @Operation(
+            summary = "[멤버] 팀 투표 템플릿 조회",
+            description = "1단계 팀 투표 화면을 그릴 템플릿과 팀 목록을 조회합니다.\n\n- 본인 팀은 isOwnTeam=true 로 표시")
+    @SecurityRequirement(name = "JWT")
+    public TeamVoteTemplateResponse getTeamVoteTemplate(
+            @AuthenticationPrincipal final Long userId, @PathVariable final Long voteId) {
+        return voteFacade.getTeamVoteTemplate(userId, voteId);
+    }
+
+    @GetMapping("/{voteId}/feedback/template")
+    @Operation(summary = "[멤버] 참여 경험 피드백 템플릿 조회", description = "2단계 피드백 화면을 그릴 템플릿을 조회합니다.")
+    @SecurityRequirement(name = "JWT")
+    public FeedbackTemplateResponse getFeedbackTemplate(
+            @AuthenticationPrincipal final Long userId, @PathVariable final Long voteId) {
+        return voteFacade.getFeedbackTemplate(userId, voteId);
+    }
+
+    @PostMapping("/{voteId}/responses")
+    @Operation(
+            summary = "[멤버] 투표 제출",
+            description =
+                    "팀 투표 + 피드백을 한 번에 제출합니다.\n\n"
+                            + "- OPEN 상태에서만 가능\n"
+                            + "- 1인 1응답(재투표 불가)\n"
+                            + "- 서버가 제약(선택 개수/본인 팀 제외/글자수/필수)을 재검증")
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<Void> submit(
+            @AuthenticationPrincipal final Long userId,
+            @PathVariable final Long voteId,
+            @RequestBody final VoteSubmitRequest request) {
+        voteFacade.submit(userId, voteId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/FeedbackTemplateResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/FeedbackTemplateResponse.java
@@ -1,0 +1,18 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import com.ddd.manage_attendance.core.sdui.FeedbackTemplate;
+import com.ddd.manage_attendance.domain.vote.domain.Vote;
+import com.ddd.manage_attendance.domain.vote.domain.VoteStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "[투표] 참여 경험 피드백 템플릿 응답 DTO")
+public record FeedbackTemplateResponse(
+        @Schema(description = "템플릿 버전") int templateVersion,
+        @Schema(description = "투표 상태") VoteStatus status,
+        @Schema(description = "피드백 템플릿 정의") FeedbackTemplate template) {
+
+    public static FeedbackTemplateResponse from(final Vote vote) {
+        return new FeedbackTemplateResponse(
+                vote.getTemplateVersion(), vote.getStatus(), vote.getFeedbackTemplate());
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/TeamVoteTemplateResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/TeamVoteTemplateResponse.java
@@ -1,0 +1,40 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import com.ddd.manage_attendance.core.sdui.TeamVoteTemplate;
+import com.ddd.manage_attendance.domain.team.domain.Team;
+import com.ddd.manage_attendance.domain.vote.domain.Vote;
+import com.ddd.manage_attendance.domain.vote.domain.VoteStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Objects;
+
+@Schema(title = "[투표] 팀 투표 템플릿 응답 DTO")
+public record TeamVoteTemplateResponse(
+        @Schema(description = "템플릿 버전") int templateVersion,
+        @Schema(description = "투표 상태") VoteStatus status,
+        @Schema(description = "팀 투표 템플릿 정의") TeamVoteTemplate template,
+        @Schema(description = "선택 대상 팀 목록(본인 팀 포함, isOwnTeam 으로 구분)") List<TeamItem> teams) {
+
+    @Schema(title = "팀 항목")
+    public record TeamItem(
+            @Schema(description = "팀 Id") Long teamId,
+            @Schema(description = "팀 이름", example = "iOS 1팀") String name,
+            @Schema(description = "서비스명", example = "PICKFLOW") String serviceName,
+            @Schema(description = "본인 팀 여부(true 면 선택 불가)") boolean isOwnTeam) {}
+
+    public static TeamVoteTemplateResponse from(
+            final Vote vote, final List<Team> teams, final Long ownTeamId) {
+        final List<TeamItem> items =
+                teams.stream()
+                        .map(
+                                team ->
+                                        new TeamItem(
+                                                team.getId(),
+                                                team.getName(),
+                                                team.getServiceName(),
+                                                Objects.equals(team.getId(), ownTeamId)))
+                        .toList();
+        return new TeamVoteTemplateResponse(
+                vote.getTemplateVersion(), vote.getStatus(), vote.getTeamVoteTemplate(), items);
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteCreateRequest.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteCreateRequest.java
@@ -1,0 +1,12 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import com.ddd.manage_attendance.core.sdui.FeedbackTemplate;
+import com.ddd.manage_attendance.core.sdui.TeamVoteTemplate;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "[투표] 투표 생성 요청 DTO")
+public record VoteCreateRequest(
+        @Schema(description = "기수 Id", example = "1") Long generationId,
+        @Schema(description = "투표 제목", example = "DDD 13기 최종 투표") String title,
+        @Schema(description = "팀 투표 템플릿") TeamVoteTemplate teamVoteTemplate,
+        @Schema(description = "참여 경험 피드백 템플릿") FeedbackTemplate feedbackTemplate) {}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteCreateResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteCreateResponse.java
@@ -1,0 +1,11 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "[투표] 투표 생성 응답 DTO")
+public record VoteCreateResponse(@Schema(description = "생성된 투표 Id", example = "1") Long voteId) {
+
+    public static VoteCreateResponse from(final Long voteId) {
+        return new VoteCreateResponse(voteId);
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteSubmitRequest.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteSubmitRequest.java
@@ -1,0 +1,32 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/** 멤버의 투표 제출(팀 투표 + 피드백 원자 제출). */
+@Schema(title = "[투표] 투표 제출 요청 DTO")
+public record VoteSubmitRequest(
+        @Schema(description = "팀 투표 부문별 응답") List<TeamVoteCategoryAnswer> teamVote,
+        @Schema(description = "피드백 질문별 응답") List<FeedbackQuestionAnswer> feedback) {
+
+    @Schema(title = "팀 투표 부문 응답")
+    public record TeamVoteCategoryAnswer(
+            @Schema(description = "부문 ID", example = "PLANNING") String categoryId,
+            @Schema(description = "선택한 팀 Id 목록(본인 팀 제외, 최대 N개)") List<Long> teamIds,
+            @Schema(description = "작성 사유") String reason) {}
+
+    @Schema(title = "피드백 질문 응답")
+    public record FeedbackQuestionAnswer(
+            @Schema(description = "질문 ID", example = "BEST_CURRICULUM") String questionId,
+            @Schema(description = "선택한 옵션 ID 목록(MULTI_SELECT)") List<String> optionIds,
+            @Schema(description = "텍스트 응답(LONG_TEXT)") String textValue,
+            @Schema(description = "예/아니오 응답(BOOLEAN)") Boolean boolValue) {}
+
+    public List<TeamVoteCategoryAnswer> teamVoteOrEmpty() {
+        return teamVote == null ? List.of() : teamVote;
+    }
+
+    public List<FeedbackQuestionAnswer> feedbackOrEmpty() {
+        return feedback == null ? List.of() : feedback;
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteTemplateUpdateRequest.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteTemplateUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import com.ddd.manage_attendance.core.sdui.FeedbackTemplate;
+import com.ddd.manage_attendance.core.sdui.TeamVoteTemplate;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "[투표] 템플릿 수정 요청 DTO (DRAFT 상태만)")
+public record VoteTemplateUpdateRequest(
+        @Schema(description = "팀 투표 템플릿") TeamVoteTemplate teamVoteTemplate,
+        @Schema(description = "참여 경험 피드백 템플릿") FeedbackTemplate feedbackTemplate) {}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/FeedbackAnswer.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/FeedbackAnswer.java
@@ -1,0 +1,101 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import com.ddd.manage_attendance.core.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+/**
+ * 피드백 응답 1건. 질문 타입에 따라 채워지는 값이 다르다.
+ *
+ * <ul>
+ *   <li>MULTI_SELECT — {@code optionId} (선택지마다 1행)
+ *   <li>LONG_TEXT — {@code textValue}
+ *   <li>BOOLEAN — {@code boolValue}
+ * </ul>
+ *
+ * {@code questionId} 는 템플릿의 안정 시맨틱 ID 이므로 라벨이 바뀌어도 집계가 유지된다.
+ */
+@Getter
+@Entity
+@Table(name = "feedback_answer")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FeedbackAnswer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @NotNull
+    @Comment("응답 Id")
+    @Column(name = "response_id", nullable = false, columnDefinition = "bigint")
+    private Long responseId;
+
+    @NotNull
+    @Comment("질문 Id (템플릿의 안정 시맨틱 Id)")
+    @Column(name = "question_id", nullable = false, columnDefinition = "varchar(100)")
+    private String questionId;
+
+    @Comment("선택지 ID (MULTI_SELECT)")
+    @Column(name = "option_id", nullable = true, columnDefinition = "varchar(100)")
+    private String optionId;
+
+    @Comment("텍스트 응답 (LONG_TEXT)")
+    @Column(name = "text_value", nullable = true, columnDefinition = "varchar(500)")
+    private String textValue;
+
+    @Comment("예/아니오 응답 (BOOLEAN)")
+    @Column(name = "bool_value", nullable = true, columnDefinition = "bit(1)")
+    private Boolean boolValue;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public FeedbackAnswer(
+            Long responseId,
+            String questionId,
+            String optionId,
+            String textValue,
+            Boolean boolValue) {
+        this.responseId = responseId;
+        this.questionId = questionId;
+        this.optionId = optionId;
+        this.textValue = textValue;
+        this.boolValue = boolValue;
+    }
+
+    public static FeedbackAnswer ofOption(
+            final Long responseId, final String questionId, final String optionId) {
+        return FeedbackAnswer.builder()
+                .responseId(responseId)
+                .questionId(questionId)
+                .optionId(optionId)
+                .build();
+    }
+
+    public static FeedbackAnswer ofText(
+            final Long responseId, final String questionId, final String textValue) {
+        return FeedbackAnswer.builder()
+                .responseId(responseId)
+                .questionId(questionId)
+                .textValue(textValue)
+                .build();
+    }
+
+    public static FeedbackAnswer ofBool(
+            final Long responseId, final String questionId, final Boolean boolValue) {
+        return FeedbackAnswer.builder()
+                .responseId(responseId)
+                .questionId(questionId)
+                .boolValue(boolValue)
+                .build();
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/FeedbackAnswerRepository.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/FeedbackAnswerRepository.java
@@ -1,0 +1,9 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedbackAnswerRepository extends JpaRepository<FeedbackAnswer, Long> {
+
+    List<FeedbackAnswer> findByResponseId(Long responseId);
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/FeedbackTemplateConverter.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/FeedbackTemplateConverter.java
@@ -1,0 +1,39 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import com.ddd.manage_attendance.core.sdui.FeedbackTemplate;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.springframework.util.StringUtils;
+
+/** {@link FeedbackTemplate} 을 text 컬럼에 JSON 으로 직렬화/역직렬화한다. (기존 @Convert 선례 준수) */
+@Converter
+public class FeedbackTemplateConverter implements AttributeConverter<FeedbackTemplate, String> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(final FeedbackTemplate attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        try {
+            return MAPPER.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("피드백 템플릿 직렬화에 실패했습니다.", e);
+        }
+    }
+
+    @Override
+    public FeedbackTemplate convertToEntityAttribute(final String dbData) {
+        if (!StringUtils.hasText(dbData)) {
+            return null;
+        }
+        try {
+            return MAPPER.readValue(dbData, FeedbackTemplate.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("피드백 템플릿 역직렬화에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteAnswer.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteAnswer.java
@@ -1,0 +1,62 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import com.ddd.manage_attendance.core.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+/**
+ * 팀 투표 선택 1건(부문별 선택 팀). {@code (response, category, team)} 단위의 정규화 행으로, 부문별 득표 집계가 순수 SQL 로 가능하다.
+ * 부문별 작성 사유는 {@link TeamVoteReason} 에 별도 보관한다.
+ */
+@Getter
+@Entity
+@Table(name = "team_vote_answer")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamVoteAnswer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @NotNull
+    @Comment("응답 Id")
+    @Column(name = "response_id", nullable = false, columnDefinition = "bigint")
+    private Long responseId;
+
+    @NotNull
+    @Comment("부문 Id (템플릿의 안정 시맨틱 Id)")
+    @Column(name = "category_id", nullable = false, columnDefinition = "varchar(100)")
+    private String categoryId;
+
+    @NotNull
+    @Comment("선택한 팀 Id")
+    @Column(name = "team_id", nullable = false, columnDefinition = "bigint")
+    private Long teamId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public TeamVoteAnswer(Long responseId, String categoryId, Long teamId) {
+        this.responseId = responseId;
+        this.categoryId = categoryId;
+        this.teamId = teamId;
+    }
+
+    public static TeamVoteAnswer create(
+            final Long responseId, final String categoryId, final Long teamId) {
+        return TeamVoteAnswer.builder()
+                .responseId(responseId)
+                .categoryId(categoryId)
+                .teamId(teamId)
+                .build();
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteAnswerRepository.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteAnswerRepository.java
@@ -1,0 +1,9 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamVoteAnswerRepository extends JpaRepository<TeamVoteAnswer, Long> {
+
+    List<TeamVoteAnswer> findByResponseId(Long responseId);
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteReason.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteReason.java
@@ -1,0 +1,58 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import com.ddd.manage_attendance.core.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+/** 팀 투표 부문별 작성 사유(부문당 1건). */
+@Getter
+@Entity
+@Table(name = "team_vote_reason")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamVoteReason extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @NotNull
+    @Comment("응답 Id")
+    @Column(name = "response_id", nullable = false, columnDefinition = "bigint")
+    private Long responseId;
+
+    @NotNull
+    @Comment("부문 Id (템플릿의 안정 시맨틱 Id)")
+    @Column(name = "category_id", nullable = false, columnDefinition = "varchar(100)")
+    private String categoryId;
+
+    @Comment("작성 사유")
+    @Column(name = "reason", columnDefinition = "varchar(500)")
+    private String reason;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public TeamVoteReason(Long responseId, String categoryId, String reason) {
+        this.responseId = responseId;
+        this.categoryId = categoryId;
+        this.reason = reason;
+    }
+
+    public static TeamVoteReason create(
+            final Long responseId, final String categoryId, final String reason) {
+        return TeamVoteReason.builder()
+                .responseId(responseId)
+                .categoryId(categoryId)
+                .reason(reason)
+                .build();
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteReasonRepository.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteReasonRepository.java
@@ -1,0 +1,9 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamVoteReasonRepository extends JpaRepository<TeamVoteReason, Long> {
+
+    List<TeamVoteReason> findByResponseId(Long responseId);
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteTemplateConverter.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteTemplateConverter.java
@@ -1,0 +1,39 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import com.ddd.manage_attendance.core.sdui.TeamVoteTemplate;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.springframework.util.StringUtils;
+
+/** {@link TeamVoteTemplate} 을 text 컬럼에 JSON 으로 직렬화/역직렬화한다. (기존 @Convert 선례 준수) */
+@Converter
+public class TeamVoteTemplateConverter implements AttributeConverter<TeamVoteTemplate, String> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(final TeamVoteTemplate attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        try {
+            return MAPPER.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("팀 투표 템플릿 직렬화에 실패했습니다.", e);
+        }
+    }
+
+    @Override
+    public TeamVoteTemplate convertToEntityAttribute(final String dbData) {
+        if (!StringUtils.hasText(dbData)) {
+            return null;
+        }
+        try {
+            return MAPPER.readValue(dbData, TeamVoteTemplate.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("팀 투표 템플릿 역직렬화에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/Vote.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/Vote.java
@@ -1,0 +1,158 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import com.ddd.manage_attendance.core.common.BaseEntity;
+import com.ddd.manage_attendance.core.sdui.FeedbackTemplate;
+import com.ddd.manage_attendance.core.sdui.TeamVoteTemplate;
+import com.ddd.manage_attendance.domain.vote.exception.VoteInvalidStatusException;
+import com.ddd.manage_attendance.domain.vote.exception.VoteNotDraftException;
+import com.ddd.manage_attendance.domain.vote.exception.VoteNotOpenException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+/**
+ * 투표(한 기수에 하나씩 열림). 라이프사이클(상태·기수)을 소유하며, 관심사가 다른 두 영역(팀 투표 / 참여 경험 피드백)의 템플릿을 불변 스냅샷으로 보유한다.
+ *
+ * <p>템플릿은 DRAFT 상태에서만 수정 가능하며, OPEN 시점에 고정(freeze)된다. 응답은 자신이 답한 {@code templateVersion} 을 핀하여 과거
+ * 해석을 보장한다.
+ */
+@Getter
+@Entity
+@Table(name = "vote")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Vote extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @NotNull
+    @Comment("기수 Id")
+    @Column(name = "generation_id", nullable = false, columnDefinition = "bigint")
+    private Long generationId;
+
+    @NotNull
+    @Comment("투표 제목")
+    @Column(name = "title", nullable = false, columnDefinition = "varchar(100)")
+    private String title;
+
+    @NotNull
+    @Comment("투표 상태 (DRAFT/OPEN/CLOSED)")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, columnDefinition = "varchar(20)")
+    private VoteStatus status;
+
+    @Comment("템플릿 버전 (수정 시마다 증가)")
+    @Column(name = "template_version", nullable = false, columnDefinition = "int")
+    private int templateVersion;
+
+    @Comment("팀 투표 템플릿 (JSON)")
+    @Convert(converter = TeamVoteTemplateConverter.class)
+    @Column(name = "team_vote_template", columnDefinition = "text")
+    private TeamVoteTemplate teamVoteTemplate;
+
+    @Comment("참여 경험 피드백 템플릿 (JSON)")
+    @Convert(converter = FeedbackTemplateConverter.class)
+    @Column(name = "feedback_template", columnDefinition = "text")
+    private FeedbackTemplate feedbackTemplate;
+
+    @Comment("투표 시작 시각")
+    @Column(name = "opened_at")
+    private LocalDateTime openedAt;
+
+    @Comment("투표 종료 시각")
+    @Column(name = "closed_at")
+    private LocalDateTime closedAt;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public Vote(
+            Long generationId,
+            String title,
+            VoteStatus status,
+            int templateVersion,
+            TeamVoteTemplate teamVoteTemplate,
+            FeedbackTemplate feedbackTemplate) {
+        this.generationId = generationId;
+        this.title = title;
+        this.status = status;
+        this.templateVersion = templateVersion;
+        this.teamVoteTemplate = teamVoteTemplate;
+        this.feedbackTemplate = feedbackTemplate;
+    }
+
+    public static Vote createDraft(
+            final Long generationId,
+            final String title,
+            final TeamVoteTemplate teamVoteTemplate,
+            final FeedbackTemplate feedbackTemplate) {
+        return Vote.builder()
+                .generationId(generationId)
+                .title(title)
+                .status(VoteStatus.DRAFT)
+                .templateVersion(1)
+                .teamVoteTemplate(teamVoteTemplate)
+                .feedbackTemplate(feedbackTemplate)
+                .build();
+    }
+
+    /** 템플릿 수정. DRAFT 상태에서만 허용되며 버전을 증가시킨다. */
+    public void updateTemplates(
+            final TeamVoteTemplate teamVoteTemplate, final FeedbackTemplate feedbackTemplate) {
+        validateDraft();
+        this.teamVoteTemplate = teamVoteTemplate;
+        this.feedbackTemplate = feedbackTemplate;
+        this.templateVersion += 1;
+    }
+
+    /** 투표 시작. DRAFT → OPEN (템플릿 freeze). */
+    public void open(final LocalDateTime now) {
+        if (this.status != VoteStatus.DRAFT) {
+            throw new VoteInvalidStatusException();
+        }
+        this.status = VoteStatus.OPEN;
+        this.openedAt = now;
+    }
+
+    /** 투표 종료. OPEN → CLOSED (불가역). */
+    public void close(final LocalDateTime now) {
+        if (this.status != VoteStatus.OPEN) {
+            throw new VoteInvalidStatusException();
+        }
+        this.status = VoteStatus.CLOSED;
+        this.closedAt = now;
+    }
+
+    public boolean isDraft() {
+        return this.status == VoteStatus.DRAFT;
+    }
+
+    public boolean isOpen() {
+        return this.status == VoteStatus.OPEN;
+    }
+
+    public void validateDraft() {
+        if (!isDraft()) {
+            throw new VoteNotDraftException();
+        }
+    }
+
+    public void validateOpen() {
+        if (!isOpen()) {
+            throw new VoteNotOpenException();
+        }
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteAnswerValidator.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteAnswerValidator.java
@@ -1,0 +1,247 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import com.ddd.manage_attendance.core.sdui.FeedbackTemplate;
+import com.ddd.manage_attendance.core.sdui.TeamVoteTemplate;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest.FeedbackQuestionAnswer;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest.TeamVoteCategoryAnswer;
+import com.ddd.manage_attendance.domain.vote.exception.OwnTeamSelectedException;
+import com.ddd.manage_attendance.domain.vote.exception.VoteAnswerInvalidException;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * 제출된 응답을 투표가 보유한 불변 템플릿으로 서버에서 재검증한다. (클라이언트 제약은 UX 용일 뿐, 신뢰 경계는 서버)
+ *
+ * <p>사유(reason)는 "해당 부문에 팀을 선택한 경우"에만 필수로 본다. 필수 피드백 질문은 최상위 질문에 한해 강제한다.
+ */
+@Component
+public class VoteAnswerValidator {
+
+    public void validate(
+            final Vote vote,
+            final Long ownTeamId,
+            final Set<Long> validTeamIds,
+            final VoteSubmitRequest request) {
+        validateTeamVote(
+                vote.getTeamVoteTemplate(), ownTeamId, validTeamIds, request.teamVoteOrEmpty());
+        validateFeedback(vote.getFeedbackTemplate(), request.feedbackOrEmpty());
+    }
+
+    private void validateTeamVote(
+            final TeamVoteTemplate template,
+            final Long ownTeamId,
+            final Set<Long> validTeamIds,
+            final List<TeamVoteCategoryAnswer> answers) {
+        if (template == null) {
+            if (!answers.isEmpty()) {
+                throw new VoteAnswerInvalidException("팀 투표 템플릿이 존재하지 않습니다.");
+            }
+            return;
+        }
+
+        final Map<String, TeamVoteTemplate.Category> categories =
+                template.categories().stream()
+                        .collect(
+                                Collectors.toMap(
+                                        TeamVoteTemplate.Category::id, Function.identity()));
+
+        final Set<String> seenCategoryIds = new HashSet<>();
+        for (final TeamVoteCategoryAnswer answer : answers) {
+            final TeamVoteTemplate.Category category = categories.get(answer.categoryId());
+            if (category == null) {
+                throw new VoteAnswerInvalidException("존재하지 않는 부문입니다: " + answer.categoryId());
+            }
+            if (!seenCategoryIds.add(answer.categoryId())) {
+                throw new VoteAnswerInvalidException("부문이 중복 제출되었습니다: " + answer.categoryId());
+            }
+
+            final List<Long> teamIds = answer.teamIds() == null ? List.of() : answer.teamIds();
+            if (teamIds.size() != new HashSet<>(teamIds).size()) {
+                throw new VoteAnswerInvalidException("같은 팀을 중복 선택했습니다.");
+            }
+            if (teamIds.size() > category.maxSelectableTeams()) {
+                throw new VoteAnswerInvalidException(
+                        "부문 '%s' 은 최대 %d개 팀까지 선택할 수 있습니다."
+                                .formatted(category.title(), category.maxSelectableTeams()));
+            }
+            for (final Long teamId : teamIds) {
+                if (Objects.equals(teamId, ownTeamId)) {
+                    throw new OwnTeamSelectedException();
+                }
+                if (!validTeamIds.contains(teamId)) {
+                    throw new VoteAnswerInvalidException("선택할 수 없는 팀입니다: " + teamId);
+                }
+            }
+            validateReason(category, answer.reason(), !teamIds.isEmpty());
+        }
+    }
+
+    private void validateReason(
+            final TeamVoteTemplate.Category category,
+            final String reason,
+            final boolean teamSelected) {
+        final boolean hasReason = StringUtils.hasText(reason);
+        if (category.reasonRequired() && teamSelected && !hasReason) {
+            throw new VoteAnswerInvalidException(
+                    "부문 '%s' 의 사유를 입력해주세요.".formatted(category.title()));
+        }
+        if (hasReason) {
+            final int length = reason.trim().length();
+            if (length < category.reasonMinLength()) {
+                throw new VoteAnswerInvalidException(
+                        "부문 '%s' 의 사유는 최소 %d자 이상 입력해주세요."
+                                .formatted(category.title(), category.reasonMinLength()));
+            }
+            if (length > category.reasonMaxLength()) {
+                throw new VoteAnswerInvalidException(
+                        "부문 '%s' 의 사유는 최대 %d자까지 입력할 수 있습니다."
+                                .formatted(category.title(), category.reasonMaxLength()));
+            }
+        }
+    }
+
+    private void validateFeedback(
+            final FeedbackTemplate template, final List<FeedbackQuestionAnswer> answers) {
+        if (template == null) {
+            if (!answers.isEmpty()) {
+                throw new VoteAnswerInvalidException("피드백 템플릿이 존재하지 않습니다.");
+            }
+            return;
+        }
+
+        final Map<String, FeedbackTemplate.Question> questionById =
+                indexQuestions(template.questions());
+        final Map<String, FeedbackQuestionAnswer> answerById = new LinkedHashMap<>();
+        for (final FeedbackQuestionAnswer answer : answers) {
+            final FeedbackTemplate.Question question = questionById.get(answer.questionId());
+            if (question == null) {
+                throw new VoteAnswerInvalidException("존재하지 않는 질문입니다: " + answer.questionId());
+            }
+            if (answerById.put(answer.questionId(), answer) != null) {
+                throw new VoteAnswerInvalidException("질문이 중복 제출되었습니다: " + answer.questionId());
+            }
+            validateAnswerByType(question, answer);
+        }
+
+        for (final FeedbackTemplate.Question question : template.questions()) {
+            if (question.required() && !hasValue(question, answerById.get(question.id()))) {
+                throw new VoteAnswerInvalidException("필수 질문에 응답해주세요: " + question.title());
+            }
+        }
+    }
+
+    private Map<String, FeedbackTemplate.Question> indexQuestions(
+            final List<FeedbackTemplate.Question> questions) {
+        final Map<String, FeedbackTemplate.Question> map = new LinkedHashMap<>();
+        for (final FeedbackTemplate.Question question : questions) {
+            indexQuestion(question, map);
+        }
+        return map;
+    }
+
+    // follow-up 은 재귀적으로 중첩될 수 있으므로 끝까지 인덱싱한다.
+    private void indexQuestion(
+            final FeedbackTemplate.Question question,
+            final Map<String, FeedbackTemplate.Question> map) {
+        map.put(question.id(), question);
+        if (question.followUp() != null) {
+            indexQuestion(question.followUp(), map);
+        }
+    }
+
+    private void validateAnswerByType(
+            final FeedbackTemplate.Question question, final FeedbackQuestionAnswer answer) {
+        final boolean hasOptions = answer.optionIds() != null && !answer.optionIds().isEmpty();
+        final boolean hasText = StringUtils.hasText(answer.textValue());
+        final boolean hasBool = answer.boolValue() != null;
+
+        switch (question.type()) {
+            case MULTI_SELECT -> {
+                if (hasText || hasBool) {
+                    throw mismatchedFields(question);
+                }
+                validateMultiSelect(question, answer);
+            }
+            case LONG_TEXT -> {
+                if (hasOptions || hasBool) {
+                    throw mismatchedFields(question);
+                }
+                validateLongText(question, answer);
+            }
+            case BOOLEAN -> {
+                // boolValue 존재 여부만 의미가 있으며, 선택지/텍스트가 함께 오면 안 된다.
+                if (hasOptions || hasText) {
+                    throw mismatchedFields(question);
+                }
+            }
+            case TEAM_SELECT ->
+                    throw new VoteAnswerInvalidException(
+                            "피드백 질문에 허용되지 않는 타입입니다: " + question.title());
+        }
+    }
+
+    private VoteAnswerInvalidException mismatchedFields(final FeedbackTemplate.Question question) {
+        return new VoteAnswerInvalidException(
+                "질문 '%s' 에 타입과 맞지 않는 값이 함께 전달되었습니다.".formatted(question.title()));
+    }
+
+    private void validateMultiSelect(
+            final FeedbackTemplate.Question question, final FeedbackQuestionAnswer answer) {
+        final List<String> optionIds = answer.optionIds() == null ? List.of() : answer.optionIds();
+        if (optionIds.size() != new HashSet<>(optionIds).size()) {
+            throw new VoteAnswerInvalidException(
+                    "질문 '%s' 에서 같은 선택지를 중복 선택했습니다.".formatted(question.title()));
+        }
+        final Set<String> validOptionIds =
+                question.options() == null
+                        ? Set.of()
+                        : question.options().stream()
+                                .map(FeedbackTemplate.Option::id)
+                                .collect(Collectors.toSet());
+        for (final String optionId : optionIds) {
+            if (!validOptionIds.contains(optionId)) {
+                throw new VoteAnswerInvalidException(
+                        "질문 '%s' 에 없는 선택지입니다: %s".formatted(question.title(), optionId));
+            }
+        }
+        if (question.maxSelectableOptions() != null
+                && optionIds.size() > question.maxSelectableOptions()) {
+            throw new VoteAnswerInvalidException(
+                    "질문 '%s' 은 최대 %d개까지 선택할 수 있습니다."
+                            .formatted(question.title(), question.maxSelectableOptions()));
+        }
+    }
+
+    private void validateLongText(
+            final FeedbackTemplate.Question question, final FeedbackQuestionAnswer answer) {
+        if (StringUtils.hasText(answer.textValue())
+                && question.maxLength() != null
+                && answer.textValue().length() > question.maxLength()) {
+            throw new VoteAnswerInvalidException(
+                    "질문 '%s' 은 최대 %d자까지 입력할 수 있습니다."
+                            .formatted(question.title(), question.maxLength()));
+        }
+    }
+
+    private boolean hasValue(
+            final FeedbackTemplate.Question question, final FeedbackQuestionAnswer answer) {
+        if (answer == null) {
+            return false;
+        }
+        return switch (question.type()) {
+            case MULTI_SELECT -> answer.optionIds() != null && !answer.optionIds().isEmpty();
+            case LONG_TEXT -> StringUtils.hasText(answer.textValue());
+            case BOOLEAN -> answer.boolValue() != null;
+            case TEAM_SELECT -> false;
+        };
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteFacade.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteFacade.java
@@ -1,0 +1,96 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import com.ddd.manage_attendance.core.util.TimeProvider;
+import com.ddd.manage_attendance.domain.auth.domain.User;
+import com.ddd.manage_attendance.domain.auth.domain.UserService;
+import com.ddd.manage_attendance.domain.team.domain.Team;
+import com.ddd.manage_attendance.domain.team.domain.TeamService;
+import com.ddd.manage_attendance.domain.vote.api.dto.FeedbackTemplateResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.TeamVoteTemplateResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteCreateRequest;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteTemplateUpdateRequest;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class VoteFacade {
+
+    private final VoteService voteService;
+    private final UserService userService;
+    private final TeamService teamService;
+    private final VoteAnswerValidator voteAnswerValidator;
+    private final TimeProvider timeProvider;
+
+    @Transactional(readOnly = true)
+    public TeamVoteTemplateResponse getTeamVoteTemplate(final Long userId, final Long voteId) {
+        final User user = userService.getUser(userId);
+        final Vote vote = voteService.getVote(voteId);
+        final List<Team> teams = teamService.findAllByGenerationId(vote.getGenerationId());
+        return TeamVoteTemplateResponse.from(vote, teams, user.getTeamId());
+    }
+
+    @Transactional(readOnly = true)
+    public FeedbackTemplateResponse getFeedbackTemplate(final Long userId, final Long voteId) {
+        userService.getUser(userId);
+        final Vote vote = voteService.getVote(voteId);
+        return FeedbackTemplateResponse.from(vote);
+    }
+
+    @Transactional
+    public void submit(final Long userId, final Long voteId, final VoteSubmitRequest request) {
+        final User user = userService.getUser(userId);
+        final Vote vote = voteService.getVote(voteId);
+        vote.validateOpen();
+
+        final List<Team> teams = teamService.findAllByGenerationId(vote.getGenerationId());
+        final Set<Long> validTeamIds = teams.stream().map(Team::getId).collect(Collectors.toSet());
+
+        voteAnswerValidator.validate(vote, user.getTeamId(), validTeamIds, request);
+        voteService.submitResponse(
+                vote, user.getId(), user.getTeamId(), user.getGenerationId(), request);
+    }
+
+    @Transactional
+    public Long createVote(final Long userId, final VoteCreateRequest request) {
+        final User manager = userService.getUser(userId);
+        manager.validateManager();
+        final Vote vote =
+                voteService.createDraft(
+                        request.generationId(),
+                        request.title(),
+                        request.teamVoteTemplate(),
+                        request.feedbackTemplate());
+        return vote.getId();
+    }
+
+    @Transactional
+    public void updateTemplate(
+            final Long userId, final Long voteId, final VoteTemplateUpdateRequest request) {
+        final User manager = userService.getUser(userId);
+        manager.validateManager();
+        final Vote vote = voteService.getVote(voteId);
+        vote.updateTemplates(request.teamVoteTemplate(), request.feedbackTemplate());
+    }
+
+    @Transactional
+    public void openVote(final Long userId, final Long voteId) {
+        final User manager = userService.getUser(userId);
+        manager.validateManager();
+        final Vote vote = voteService.getVote(voteId);
+        vote.open(timeProvider.nowDateTime());
+    }
+
+    @Transactional
+    public void closeVote(final Long userId, final Long voteId) {
+        final User manager = userService.getUser(userId);
+        manager.validateManager();
+        final Vote vote = voteService.getVote(voteId);
+        vote.close(timeProvider.nowDateTime());
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteRepository.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteRepository.java
@@ -1,0 +1,5 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoteRepository extends JpaRepository<Vote, Long> {}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteResponse.java
@@ -1,0 +1,90 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import com.ddd.manage_attendance.core.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+/**
+ * 한 멤버의 투표 응답(투표당 1인 1응답). {@code (vote_id, member_id)} 유니크 제약으로 멱등성을 보장한다.
+ *
+ * <p>회원의 teamId/generationId 가 프로필 수정으로 가변이므로, 제출 시점의 소속을 스냅샷으로 보관하여 "본인 팀 제외"·집계 해석의 정합성을 유지한다.
+ */
+@Getter
+@Entity
+@Table(
+        name = "vote_response",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_vote_response_vote_member",
+                    columnNames = {"vote_id", "member_id"})
+        })
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VoteResponse extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @NotNull
+    @Comment("투표 Id")
+    @Column(name = "vote_id", nullable = false, columnDefinition = "bigint")
+    private Long voteId;
+
+    @NotNull
+    @Comment("응답한 멤버 Id")
+    @Column(name = "member_id", nullable = false, columnDefinition = "bigint")
+    private Long memberId;
+
+    @Comment("응답 시점에 고정된 템플릿 버전")
+    @Column(name = "template_version", nullable = false, columnDefinition = "int")
+    private int templateVersion;
+
+    @Comment("제출 시점 소속 팀 Id 스냅샷")
+    @Column(name = "snapshot_team_id", nullable = true, columnDefinition = "bigint")
+    private Long snapshotTeamId;
+
+    @Comment("제출 시점 소속 기수 Id 스냅샷")
+    @Column(name = "snapshot_generation_id", nullable = true, columnDefinition = "bigint")
+    private Long snapshotGenerationId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public VoteResponse(
+            Long voteId,
+            Long memberId,
+            int templateVersion,
+            Long snapshotTeamId,
+            Long snapshotGenerationId) {
+        this.voteId = voteId;
+        this.memberId = memberId;
+        this.templateVersion = templateVersion;
+        this.snapshotTeamId = snapshotTeamId;
+        this.snapshotGenerationId = snapshotGenerationId;
+    }
+
+    public static VoteResponse create(
+            final Long voteId,
+            final Long memberId,
+            final int templateVersion,
+            final Long snapshotTeamId,
+            final Long snapshotGenerationId) {
+        return VoteResponse.builder()
+                .voteId(voteId)
+                .memberId(memberId)
+                .templateVersion(templateVersion)
+                .snapshotTeamId(snapshotTeamId)
+                .snapshotGenerationId(snapshotGenerationId)
+                .build();
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteResponseRepository.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteResponseRepository.java
@@ -1,0 +1,11 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoteResponseRepository extends JpaRepository<VoteResponse, Long> {
+
+    Optional<VoteResponse> findByVoteIdAndMemberId(Long voteId, Long memberId);
+
+    boolean existsByVoteIdAndMemberId(Long voteId, Long memberId);
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteService.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteService.java
@@ -1,0 +1,115 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import com.ddd.manage_attendance.core.sdui.FeedbackTemplate;
+import com.ddd.manage_attendance.core.sdui.TeamVoteTemplate;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest.FeedbackQuestionAnswer;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest.TeamVoteCategoryAnswer;
+import com.ddd.manage_attendance.domain.vote.exception.VoteAlreadyRespondedException;
+import com.ddd.manage_attendance.domain.vote.exception.VoteNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class VoteService {
+
+    private final VoteRepository voteRepository;
+    private final VoteResponseRepository voteResponseRepository;
+    private final TeamVoteAnswerRepository teamVoteAnswerRepository;
+    private final TeamVoteReasonRepository teamVoteReasonRepository;
+    private final FeedbackAnswerRepository feedbackAnswerRepository;
+
+    @Transactional(readOnly = true)
+    public Vote getVote(final Long voteId) {
+        return voteRepository.findById(voteId).orElseThrow(VoteNotFoundException::new);
+    }
+
+    @Transactional
+    public Vote createDraft(
+            final Long generationId,
+            final String title,
+            final TeamVoteTemplate teamVoteTemplate,
+            final FeedbackTemplate feedbackTemplate) {
+        return voteRepository.save(
+                Vote.createDraft(generationId, title, teamVoteTemplate, feedbackTemplate));
+    }
+
+    /** 멱등 제출. (vote_id, member_id) 유니크 제약 + 동시성 예외 처리로 1인 1응답을 보장한다. 재투표는 거부한다. */
+    @Transactional
+    public void submitResponse(
+            final Vote vote,
+            final Long memberId,
+            final Long snapshotTeamId,
+            final Long snapshotGenerationId,
+            final VoteSubmitRequest request) {
+        if (voteResponseRepository.existsByVoteIdAndMemberId(vote.getId(), memberId)) {
+            throw new VoteAlreadyRespondedException();
+        }
+
+        final VoteResponse response;
+        try {
+            response =
+                    voteResponseRepository.save(
+                            VoteResponse.create(
+                                    vote.getId(),
+                                    memberId,
+                                    vote.getTemplateVersion(),
+                                    snapshotTeamId,
+                                    snapshotGenerationId));
+        } catch (DataIntegrityViolationException e) {
+            // 동시 제출로 유니크 제약 위반 -> 이미 참여한 것으로 처리
+            throw new VoteAlreadyRespondedException();
+        }
+
+        saveTeamVoteAnswers(response.getId(), request.teamVoteOrEmpty());
+        saveFeedbackAnswers(response.getId(), request.feedbackOrEmpty());
+    }
+
+    private void saveTeamVoteAnswers(
+            final Long responseId, final List<TeamVoteCategoryAnswer> answers) {
+        final List<TeamVoteAnswer> picks = new ArrayList<>();
+        final List<TeamVoteReason> reasons = new ArrayList<>();
+        for (final TeamVoteCategoryAnswer answer : answers) {
+            if (answer.teamIds() != null) {
+                for (final Long teamId : answer.teamIds()) {
+                    picks.add(TeamVoteAnswer.create(responseId, answer.categoryId(), teamId));
+                }
+            }
+            if (StringUtils.hasText(answer.reason())) {
+                reasons.add(
+                        TeamVoteReason.create(
+                                responseId, answer.categoryId(), answer.reason().trim()));
+            }
+        }
+        teamVoteAnswerRepository.saveAll(picks);
+        teamVoteReasonRepository.saveAll(reasons);
+    }
+
+    private void saveFeedbackAnswers(
+            final Long responseId, final List<FeedbackQuestionAnswer> answers) {
+        final List<FeedbackAnswer> rows = new ArrayList<>();
+        for (final FeedbackQuestionAnswer answer : answers) {
+            if (answer.optionIds() != null) {
+                for (final String optionId : answer.optionIds()) {
+                    rows.add(FeedbackAnswer.ofOption(responseId, answer.questionId(), optionId));
+                }
+            }
+            if (StringUtils.hasText(answer.textValue())) {
+                rows.add(
+                        FeedbackAnswer.ofText(
+                                responseId, answer.questionId(), answer.textValue().trim()));
+            }
+            if (answer.boolValue() != null) {
+                rows.add(
+                        FeedbackAnswer.ofBool(responseId, answer.questionId(), answer.boolValue()));
+            }
+        }
+        feedbackAnswerRepository.saveAll(rows);
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteStatus.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteStatus.java
@@ -1,0 +1,15 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** 투표 상태머신. DRAFT(작성중) → OPEN(진행중) → CLOSED(종료). 종료 후 재시작 불가(불가역). */
+@Getter
+@RequiredArgsConstructor
+public enum VoteStatus {
+    DRAFT("작성중"),
+    OPEN("진행중"),
+    CLOSED("종료");
+
+    private final String description;
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/exception/OwnTeamSelectedException.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/exception/OwnTeamSelectedException.java
@@ -1,0 +1,11 @@
+package com.ddd.manage_attendance.domain.vote.exception;
+
+import com.ddd.manage_attendance.core.exception.BaseException;
+import com.ddd.manage_attendance.core.exception.ErrorCode;
+
+public class OwnTeamSelectedException extends BaseException {
+
+    public OwnTeamSelectedException() {
+        super(ErrorCode.VOTE_OWN_TEAM_SELECTED);
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteAlreadyRespondedException.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteAlreadyRespondedException.java
@@ -1,0 +1,11 @@
+package com.ddd.manage_attendance.domain.vote.exception;
+
+import com.ddd.manage_attendance.core.exception.BaseException;
+import com.ddd.manage_attendance.core.exception.ErrorCode;
+
+public class VoteAlreadyRespondedException extends BaseException {
+
+    public VoteAlreadyRespondedException() {
+        super(ErrorCode.VOTE_ALREADY_RESPONDED);
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteAnswerInvalidException.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteAnswerInvalidException.java
@@ -1,0 +1,12 @@
+package com.ddd.manage_attendance.domain.vote.exception;
+
+import com.ddd.manage_attendance.core.exception.BaseException;
+import com.ddd.manage_attendance.core.exception.ErrorCode;
+
+/** 제출된 응답이 템플릿 제약(선택 개수/글자수/필수 등)을 위반한 경우. 구체 사유를 커스텀 메시지로 전달한다. */
+public class VoteAnswerInvalidException extends BaseException {
+
+    public VoteAnswerInvalidException(final String message) {
+        super(ErrorCode.VOTE_ANSWER_INVALID, message);
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteInvalidStatusException.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteInvalidStatusException.java
@@ -1,0 +1,11 @@
+package com.ddd.manage_attendance.domain.vote.exception;
+
+import com.ddd.manage_attendance.core.exception.BaseException;
+import com.ddd.manage_attendance.core.exception.ErrorCode;
+
+public class VoteInvalidStatusException extends BaseException {
+
+    public VoteInvalidStatusException() {
+        super(ErrorCode.VOTE_INVALID_STATUS);
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteNotDraftException.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteNotDraftException.java
@@ -1,0 +1,11 @@
+package com.ddd.manage_attendance.domain.vote.exception;
+
+import com.ddd.manage_attendance.core.exception.BaseException;
+import com.ddd.manage_attendance.core.exception.ErrorCode;
+
+public class VoteNotDraftException extends BaseException {
+
+    public VoteNotDraftException() {
+        super(ErrorCode.VOTE_NOT_DRAFT);
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteNotFoundException.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteNotFoundException.java
@@ -1,0 +1,11 @@
+package com.ddd.manage_attendance.domain.vote.exception;
+
+import com.ddd.manage_attendance.core.exception.BaseException;
+import com.ddd.manage_attendance.core.exception.ErrorCode;
+
+public class VoteNotFoundException extends BaseException {
+
+    public VoteNotFoundException() {
+        super(ErrorCode.VOTE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteNotOpenException.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteNotOpenException.java
@@ -1,0 +1,11 @@
+package com.ddd.manage_attendance.domain.vote.exception;
+
+import com.ddd.manage_attendance.core.exception.BaseException;
+import com.ddd.manage_attendance.core.exception.ErrorCode;
+
+public class VoteNotOpenException extends BaseException {
+
+    public VoteNotOpenException() {
+        super(ErrorCode.VOTE_NOT_OPEN);
+    }
+}

--- a/src/test/java/com/ddd/manage_attendance/domain/vote/domain/VoteAnswerValidatorTest.java
+++ b/src/test/java/com/ddd/manage_attendance/domain/vote/domain/VoteAnswerValidatorTest.java
@@ -1,0 +1,255 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ddd.manage_attendance.core.sdui.FeedbackTemplate;
+import com.ddd.manage_attendance.core.sdui.TeamVoteTemplate;
+import com.ddd.manage_attendance.core.sdui.VoteComponentType;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest.FeedbackQuestionAnswer;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest.TeamVoteCategoryAnswer;
+import com.ddd.manage_attendance.domain.vote.exception.OwnTeamSelectedException;
+import com.ddd.manage_attendance.domain.vote.exception.VoteAnswerInvalidException;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class VoteAnswerValidatorTest {
+
+    private static final Long OWN_TEAM_ID = 10L;
+    private static final Set<Long> VALID_TEAM_IDS = Set.of(10L, 11L, 12L, 13L);
+
+    private final VoteAnswerValidator validator = new VoteAnswerValidator();
+
+    private Vote voteWithTemplates() {
+        final TeamVoteTemplate teamVoteTemplate =
+                new TeamVoteTemplate(
+                        "팀 투표",
+                        "설명",
+                        "본인 팀 제외",
+                        List.of(
+                                new TeamVoteTemplate.Category(
+                                        "PLANNING", 1, "기획", 2, true, 5, 300, "사유")));
+        final FeedbackTemplate feedbackTemplate =
+                new FeedbackTemplate(
+                        "피드백",
+                        "설명",
+                        List.of(
+                                new FeedbackTemplate.Question(
+                                        "BEST",
+                                        1,
+                                        VoteComponentType.MULTI_SELECT,
+                                        "가장 만족한 커리큘럼",
+                                        "모두 선택 가능",
+                                        true,
+                                        2,
+                                        null,
+                                        List.of(
+                                                new FeedbackTemplate.Option("OT", "OT"),
+                                                new FeedbackTemplate.Option("FINAL", "최종 발표")),
+                                        new FeedbackTemplate.Question(
+                                                "BEST_REASON",
+                                                2,
+                                                VoteComponentType.LONG_TEXT,
+                                                "어떤 부분이 좋았나요?",
+                                                null,
+                                                false,
+                                                null,
+                                                300,
+                                                null,
+                                                null))));
+        return Vote.createDraft(1L, "투표", teamVoteTemplate, feedbackTemplate);
+    }
+
+    private VoteSubmitRequest request(
+            final List<TeamVoteCategoryAnswer> teamVote,
+            final List<FeedbackQuestionAnswer> feedback) {
+        return new VoteSubmitRequest(teamVote, feedback);
+    }
+
+    // TOP -> L1 -> L2 로 follow-up 이 2단계 중첩된 피드백 템플릿
+    private Vote voteWithNestedFollowUp() {
+        final FeedbackTemplate.Question deep =
+                new FeedbackTemplate.Question(
+                        "L2",
+                        3,
+                        VoteComponentType.LONG_TEXT,
+                        "심화",
+                        null,
+                        false,
+                        null,
+                        300,
+                        null,
+                        null);
+        final FeedbackTemplate.Question mid =
+                new FeedbackTemplate.Question(
+                        "L1",
+                        2,
+                        VoteComponentType.LONG_TEXT,
+                        "후속",
+                        null,
+                        false,
+                        null,
+                        300,
+                        null,
+                        deep);
+        final FeedbackTemplate.Question top =
+                new FeedbackTemplate.Question(
+                        "TOP",
+                        1,
+                        VoteComponentType.LONG_TEXT,
+                        "최상위",
+                        null,
+                        false,
+                        null,
+                        300,
+                        null,
+                        mid);
+        return Vote.createDraft(1L, "투표", null, new FeedbackTemplate("피드백", "설명", List.of(top)));
+    }
+
+    @Test
+    @DisplayName("타입과 맞지 않는 필드를 함께 보내면 예외가 발생한다")
+    void mixedTypeFields_throws() {
+        final VoteSubmitRequest request =
+                request(
+                        List.of(),
+                        List.of(
+                                new FeedbackQuestionAnswer(
+                                        "BEST", List.of("OT"), "엉뚱한 텍스트", null)));
+
+        assertThatThrownBy(
+                        () ->
+                                validator.validate(
+                                        voteWithTemplates(), OWN_TEAM_ID, VALID_TEAM_IDS, request))
+                .isInstanceOf(VoteAnswerInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("2단계 이상 중첩된 follow-up 질문 응답도 인식한다")
+    void deeplyNestedFollowUp_isRecognized() {
+        final VoteSubmitRequest request =
+                request(List.of(), List.of(new FeedbackQuestionAnswer("L2", null, "심화 응답", null)));
+
+        assertThatCode(
+                        () ->
+                                validator.validate(
+                                        voteWithNestedFollowUp(),
+                                        OWN_TEAM_ID,
+                                        VALID_TEAM_IDS,
+                                        request))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("정상 응답은 통과한다")
+    void validSubmission_passes() {
+        final VoteSubmitRequest request =
+                request(
+                        List.of(
+                                new TeamVoteCategoryAnswer(
+                                        "PLANNING", List.of(11L, 12L), "기획이 탄탄했어요")),
+                        List.of(new FeedbackQuestionAnswer("BEST", List.of("OT"), null, null)));
+
+        assertThatCode(
+                        () ->
+                                validator.validate(
+                                        voteWithTemplates(), OWN_TEAM_ID, VALID_TEAM_IDS, request))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("본인 팀을 선택하면 예외가 발생한다")
+    void ownTeamSelected_throws() {
+        final VoteSubmitRequest request =
+                request(
+                        List.of(
+                                new TeamVoteCategoryAnswer(
+                                        "PLANNING", List.of(OWN_TEAM_ID), "사유입니다")),
+                        List.of(new FeedbackQuestionAnswer("BEST", List.of("OT"), null, null)));
+
+        assertThatThrownBy(
+                        () ->
+                                validator.validate(
+                                        voteWithTemplates(), OWN_TEAM_ID, VALID_TEAM_IDS, request))
+                .isInstanceOf(OwnTeamSelectedException.class);
+    }
+
+    @Test
+    @DisplayName("부문 최대 선택 팀 수를 초과하면 예외가 발생한다")
+    void exceedMaxTeams_throws() {
+        final VoteSubmitRequest request =
+                request(
+                        List.of(
+                                new TeamVoteCategoryAnswer(
+                                        "PLANNING", List.of(11L, 12L, 13L), "사유입니다")),
+                        List.of(new FeedbackQuestionAnswer("BEST", List.of("OT"), null, null)));
+
+        assertThatThrownBy(
+                        () ->
+                                validator.validate(
+                                        voteWithTemplates(), OWN_TEAM_ID, VALID_TEAM_IDS, request))
+                .isInstanceOf(VoteAnswerInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("사유가 최소 글자수보다 짧으면 예외가 발생한다")
+    void reasonTooShort_throws() {
+        final VoteSubmitRequest request =
+                request(
+                        List.of(new TeamVoteCategoryAnswer("PLANNING", List.of(11L), "짧음")),
+                        List.of(new FeedbackQuestionAnswer("BEST", List.of("OT"), null, null)));
+
+        assertThatThrownBy(
+                        () ->
+                                validator.validate(
+                                        voteWithTemplates(), OWN_TEAM_ID, VALID_TEAM_IDS, request))
+                .isInstanceOf(VoteAnswerInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("필수 피드백 질문에 응답하지 않으면 예외가 발생한다")
+    void requiredFeedbackMissing_throws() {
+        final VoteSubmitRequest request = request(List.of(), List.of());
+
+        assertThatThrownBy(
+                        () ->
+                                validator.validate(
+                                        voteWithTemplates(), OWN_TEAM_ID, VALID_TEAM_IDS, request))
+                .isInstanceOf(VoteAnswerInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("다중 선택에서 같은 선택지를 중복 선택하면 예외가 발생한다")
+    void duplicateMultiSelect_throws() {
+        final VoteSubmitRequest request =
+                request(
+                        List.of(),
+                        List.of(
+                                new FeedbackQuestionAnswer(
+                                        "BEST", List.of("OT", "OT"), null, null)));
+
+        assertThatThrownBy(
+                        () ->
+                                validator.validate(
+                                        voteWithTemplates(), OWN_TEAM_ID, VALID_TEAM_IDS, request))
+                .isInstanceOf(VoteAnswerInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 팀을 선택하면 예외가 발생한다")
+    void unknownTeam_throws() {
+        final VoteSubmitRequest request =
+                request(
+                        List.of(new TeamVoteCategoryAnswer("PLANNING", List.of(999L), "사유입니다")),
+                        List.of(new FeedbackQuestionAnswer("BEST", List.of("OT"), null, null)));
+
+        assertThatThrownBy(
+                        () ->
+                                validator.validate(
+                                        voteWithTemplates(), OWN_TEAM_ID, VALID_TEAM_IDS, request))
+                .isInstanceOf(VoteAnswerInvalidException.class);
+    }
+}

--- a/src/test/java/com/ddd/manage_attendance/domain/vote/domain/VoteTest.java
+++ b/src/test/java/com/ddd/manage_attendance/domain/vote/domain/VoteTest.java
@@ -1,0 +1,100 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ddd.manage_attendance.domain.vote.exception.VoteInvalidStatusException;
+import com.ddd.manage_attendance.domain.vote.exception.VoteNotDraftException;
+import com.ddd.manage_attendance.domain.vote.exception.VoteNotOpenException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class VoteTest {
+
+    private Vote draftVote() {
+        return Vote.createDraft(1L, "DDD 13기 투표", null, null);
+    }
+
+    @Test
+    @DisplayName("생성 시 DRAFT 상태와 버전 1로 시작한다")
+    void createDraft_initsDraftAndVersionOne() {
+        final Vote vote = draftVote();
+
+        assertThat(vote.getStatus()).isEqualTo(VoteStatus.DRAFT);
+        assertThat(vote.getTemplateVersion()).isEqualTo(1);
+        assertThat(vote.isDraft()).isTrue();
+    }
+
+    @Test
+    @DisplayName("DRAFT 에서 open 하면 OPEN 으로 전환되고 시작 시각이 기록된다")
+    void open_fromDraft_transitionsToOpen() {
+        final Vote vote = draftVote();
+        final LocalDateTime now = LocalDateTime.of(2026, 6, 9, 10, 0);
+
+        vote.open(now);
+
+        assertThat(vote.getStatus()).isEqualTo(VoteStatus.OPEN);
+        assertThat(vote.getOpenedAt()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("DRAFT 가 아닐 때 open 하면 예외가 발생한다")
+    void open_whenNotDraft_throws() {
+        final Vote vote = draftVote();
+        vote.open(LocalDateTime.now());
+
+        assertThatThrownBy(() -> vote.open(LocalDateTime.now()))
+                .isInstanceOf(VoteInvalidStatusException.class);
+    }
+
+    @Test
+    @DisplayName("OPEN 에서 close 하면 CLOSED 로 전환된다")
+    void close_fromOpen_transitionsToClosed() {
+        final Vote vote = draftVote();
+        vote.open(LocalDateTime.now());
+        final LocalDateTime now = LocalDateTime.of(2026, 6, 9, 12, 0);
+
+        vote.close(now);
+
+        assertThat(vote.getStatus()).isEqualTo(VoteStatus.CLOSED);
+        assertThat(vote.getClosedAt()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("OPEN 이 아닐 때 close 하면 예외가 발생한다")
+    void close_whenNotOpen_throws() {
+        final Vote vote = draftVote();
+
+        assertThatThrownBy(() -> vote.close(LocalDateTime.now()))
+                .isInstanceOf(VoteInvalidStatusException.class);
+    }
+
+    @Test
+    @DisplayName("DRAFT 에서 템플릿 수정 시 버전이 증가한다")
+    void updateTemplates_inDraft_bumpsVersion() {
+        final Vote vote = draftVote();
+
+        vote.updateTemplates(null, null);
+
+        assertThat(vote.getTemplateVersion()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("DRAFT 가 아닐 때 템플릿 수정 시 예외가 발생한다")
+    void updateTemplates_whenNotDraft_throws() {
+        final Vote vote = draftVote();
+        vote.open(LocalDateTime.now());
+
+        assertThatThrownBy(() -> vote.updateTemplates(null, null))
+                .isInstanceOf(VoteNotDraftException.class);
+    }
+
+    @Test
+    @DisplayName("OPEN 이 아닐 때 validateOpen 은 예외를 던진다")
+    void validateOpen_whenNotOpen_throws() {
+        final Vote vote = draftVote();
+
+        assertThatThrownBy(vote::validateOpen).isInstanceOf(VoteNotOpenException.class);
+    }
+}


### PR DESCRIPTION
## 개요
멤버용 **팀 투표 / 참여 경험 피드백** 화면을 **서버 드리븐 UI(SDUI)** 로 제공하는 `vote` 도메인을 추가합니다.
투표는 한 기수에 1개로 열리고(상태머신 소유), 그 아래 **관심사가 다른 두 영역**(팀투표·피드백)을 각자 템플릿·응답·검증으로 분리했습니다.

## 주요 변경
- **`domain/vote`**: `Vote`(상태머신 DRAFT/OPEN/CLOSED), `VoteResponse`(1인1응답), `TeamVoteAnswer`/`TeamVoteReason`/`FeedbackAnswer`(정규화 응답), Repository 5종, `VoteService`/`VoteFacade`/`VoteAnswerValidator`, 예외 7종, `VoteController`(`/api/votes`), DTO 6종
- **`core/sdui`**: 시맨틱 컴포넌트(`VoteComponentType`) + 템플릿 record(`TeamVoteTemplate`, `FeedbackTemplate`) — 클라이언트가 렌더링 소유
- 템플릿 저장 = `text` + `AttributeConverter`(기존 선례), 응답 = 정규화 행(집계는 순수 SQL)
- **변경**: `Team`에 `serviceName` 추가, `TeamResponse` 확장, `JpaConfig` AuditorAware가 인증 userId 주입, `ErrorCode` VOTE_* 7종
- **배포**: 첫 배포용 수동 DDL `docs/sql/vote_feature.sql` (ddl-auto=update가 새 테이블 제약을 신뢰성 있게 못 만듦)

## 핵심 설계 결정
- 투표 시작 = 템플릿 freeze, 종료는 불가역 / 응답은 `templateVersion` 핀 + 제출 시점 소속 스냅샷
- 1인1응답 = `@UniqueConstraint(vote_id, member_id)` + `DataIntegrityViolationException` catch (기존 출석 패턴 미러)
- 운영진 전용(생성/수정/시작/종료)은 `validateManager()`, 멤버는 인증만
- 제약(최대 선택/본인팀 제외/글자수/필수)은 **서버에서 재검증**

## 검증
- ✅ `compileJava`, ✅ 단위테스트 **17개**(`VoteTest` 8 + `VoteAnswerValidatorTest` 9) 통과 / 0 실패
- ✅ spotless: 신규 파일 전부 준수
- ✅ 다관점 리뷰(omc·codex·superpowers): 아키텍처/컨벤션/머지적합성 — 머지 전 지적된 2개 결함(혼합 타입 필드 거부, follow-up 재귀 인덱싱) 수정 + 회귀 테스트 추가

## 참고 / 후속
- 팀 항목 `serviceName`은 nullable로 추가 — 데이터 적재 필요
- 운영진 실시간 집계 조회 API는 후속 PR 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)