### PR TITLE
feat: 투표 조회 API 추가 + 리뷰 반영 (참여현황/미참여명단/진행중투표/내참여여부)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ out/
 ### Private Keys ###
 *.p8
 **/keys/*.p8
+
+### 로컬 Postman 테스트 전용 (커밋 금지) ###
+src/main/resources/application-local.yml
+src/main/resources/seed/
+docs/local-test/

--- a/src/main/java/com/ddd/manage_attendance/core/exception/ErrorCode.java
+++ b/src/main/java/com/ddd/manage_attendance/core/exception/ErrorCode.java
@@ -37,6 +37,8 @@ public enum ErrorCode {
     VOTE_OWN_TEAM_SELECTED(HttpStatus.BAD_REQUEST, "본인 팀은 투표할 수 없습니다."),
     VOTE_ANSWER_INVALID(HttpStatus.BAD_REQUEST, "투표 응답이 제약 조건을 위반했습니다."),
     VOTE_ALREADY_RESPONDED(HttpStatus.BAD_REQUEST, "이미 투표에 참여했습니다."),
+    VOTE_NO_ACTIVE(HttpStatus.NOT_FOUND, "진행 중인 투표가 없습니다."),
+    VOTE_MANAGER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "운영진은 투표에 참여할 수 없습니다."),
 
     // 데이터 관련
     DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 데이터입니다."),

--- a/src/main/java/com/ddd/manage_attendance/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ddd/manage_attendance/core/exception/GlobalExceptionHandler.java
@@ -2,8 +2,6 @@ package com.ddd.manage_attendance.core.exception;
 
 import com.ddd.manage_attendance.domain.oauth.exception.OAuthTokenValidationException;
 import jakarta.servlet.http.HttpServletRequest;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -28,7 +26,7 @@ public class GlobalExceptionHandler {
 
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity.status(errorCode.getHttpStatus())
-                .body(ErrorResponse.of(errorCode.name(), e.getMessage(), getStackTrace(e)));
+                .body(ErrorResponse.of(errorCode.name(), e.getMessage()));
     }
 
     @ExceptionHandler(BaseException.class)
@@ -42,7 +40,7 @@ public class GlobalExceptionHandler {
 
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity.status(errorCode.getHttpStatus())
-                .body(ErrorResponse.of(errorCode.name(), e.getMessage(), getStackTrace(e)));
+                .body(ErrorResponse.of(errorCode.name(), e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -53,7 +51,7 @@ public class GlobalExceptionHandler {
 
         ErrorCode errorCode = ErrorCode.VALIDATION_ERROR;
         return ResponseEntity.status(errorCode.getHttpStatus())
-                .body(ErrorResponse.of(errorCode.name(), message, getStackTrace(e)));
+                .body(ErrorResponse.of(errorCode.name(), message));
     }
 
     @ExceptionHandler(BindException.class)
@@ -64,7 +62,7 @@ public class GlobalExceptionHandler {
 
         ErrorCode errorCode = ErrorCode.BIND_ERROR;
         return ResponseEntity.status(errorCode.getHttpStatus())
-                .body(ErrorResponse.of(errorCode.name(), message, getStackTrace(e)));
+                .body(ErrorResponse.of(errorCode.name(), message));
     }
 
     @ExceptionHandler(AccessDeniedException.class)
@@ -74,7 +72,7 @@ public class GlobalExceptionHandler {
 
         ErrorCode errorCode = ErrorCode.UNAUTHORIZED;
         return ResponseEntity.status(errorCode.getHttpStatus())
-                .body(ErrorResponse.of(errorCode.name(), errorCode.getMessage(), getStackTrace(e)));
+                .body(ErrorResponse.of(errorCode.name(), errorCode.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
@@ -87,13 +85,6 @@ public class GlobalExceptionHandler {
 
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
         return ResponseEntity.status(errorCode.getHttpStatus())
-                .body(ErrorResponse.of(errorCode.name(), errorCode.getMessage(), getStackTrace(e)));
-    }
-
-    private String getStackTrace(Exception e) {
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        e.printStackTrace(pw);
-        return sw.toString();
+                .body(ErrorResponse.of(errorCode.name(), errorCode.getMessage()));
     }
 }

--- a/src/main/java/com/ddd/manage_attendance/domain/auth/domain/UserRepository.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/auth/domain/UserRepository.java
@@ -17,4 +17,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "SELECT u FROM User u WHERE u.teamId = :teamId AND u.id <> :excludeUserId AND u.role <> :userRole")
     List<User> findUsersByTeamIdAndExcludeUserId(
             Long teamId, Long excludeUserId, UserRole userRole);
+
+    List<User> findAllByGenerationIdAndRole(Long generationId, UserRole role);
 }

--- a/src/main/java/com/ddd/manage_attendance/domain/auth/domain/UserService.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/auth/domain/UserService.java
@@ -35,6 +35,12 @@ public class UserService {
         return userRepository.findUsersByTeamIdAndExcludeUserId(teamId, excludeUserId, userRole);
     }
 
+    /** 기수에 속한 일반 멤버(운영진 제외) 목록. 투표 참여 현황/미참여 명단의 모집단으로 사용한다. */
+    @Transactional(readOnly = true)
+    public List<User> findMembersByGeneration(final Long generationId) {
+        return userRepository.findAllByGenerationIdAndRole(generationId, UserRole.MEMBER);
+    }
+
     @Transactional
     public User registerOAuthUser(
             final OAuthProvider provider,

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/VoteController.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/VoteController.java
@@ -1,9 +1,13 @@
 package com.ddd.manage_attendance.domain.vote.api;
 
+import com.ddd.manage_attendance.domain.vote.api.dto.ActiveVoteResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.FeedbackTemplateResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.MyVoteStatusResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.TeamVoteTemplateResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteCreateRequest;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteCreateResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteNonRespondersResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteParticipationResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteTemplateUpdateRequest;
 import com.ddd.manage_attendance.domain.vote.domain.VoteFacade;
@@ -108,5 +112,51 @@ public class VoteController {
             @RequestBody final VoteSubmitRequest request) {
         voteFacade.submit(userId, voteId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/active")
+    @Operation(
+            summary = "[멤버] 진행 중 투표 조회",
+            description =
+                    "내 기수에 진행 중(OPEN)인 투표가 있는지 조회합니다.\n\n"
+                            + "- 홈 메뉴의 '투표(NEW)' 노출/진입 판단에 사용\n"
+                            + "- 없으면 hasActiveVote=false\n"
+                            + "- alreadyResponded 로 완료 화면 분기")
+    @SecurityRequirement(name = "JWT")
+    public ActiveVoteResponse getActiveVote(@AuthenticationPrincipal final Long userId) {
+        return voteFacade.getActiveVote(userId);
+    }
+
+    @GetMapping("/{voteId}/responses/me")
+    @Operation(
+            summary = "[멤버] 내 참여 여부 조회",
+            description = "특정 투표에 내가 이미 참여했는지 조회합니다.\n\n- 완료/재참여 차단 화면 판단에 사용")
+    @SecurityRequirement(name = "JWT")
+    public MyVoteStatusResponse getMyVoteStatus(
+            @AuthenticationPrincipal final Long userId, @PathVariable final Long voteId) {
+        return voteFacade.getMyVoteStatus(userId, voteId);
+    }
+
+    @GetMapping("/{voteId}/participation")
+    @Operation(
+            summary = "[운영진] 투표 상태 및 참여 현황 조회",
+            description =
+                    "투표 관리 화면 데이터를 조회합니다.\n\n"
+                            + "- 운영진 권한 필수\n"
+                            + "- 투표 상태(DRAFT/OPEN/CLOSED) + 대상 멤버수/참여수/참여율(운영진 제외)")
+    @SecurityRequirement(name = "JWT")
+    public VoteParticipationResponse getParticipation(
+            @AuthenticationPrincipal final Long userId, @PathVariable final Long voteId) {
+        return voteFacade.getParticipation(userId, voteId);
+    }
+
+    @GetMapping("/{voteId}/non-responders")
+    @Operation(
+            summary = "[운영진] 미참여 멤버 명단 조회",
+            description = "아직 투표하지 않은 멤버 명단(이름 + 소속 팀명)을 조회합니다.\n\n- 운영진 권한 필수")
+    @SecurityRequirement(name = "JWT")
+    public VoteNonRespondersResponse getNonResponders(
+            @AuthenticationPrincipal final Long userId, @PathVariable final Long voteId) {
+        return voteFacade.getNonResponders(userId, voteId);
     }
 }

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/ActiveVoteResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/ActiveVoteResponse.java
@@ -1,0 +1,21 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import com.ddd.manage_attendance.domain.vote.domain.Vote;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "[투표] 진행 중 투표 조회 응답 DTO")
+public record ActiveVoteResponse(
+        @Schema(description = "진행 중(OPEN) 투표 존재 여부 (false 면 멤버 메뉴에 '투표' 미노출)")
+                boolean hasActiveVote,
+        @Schema(description = "투표 Id (없으면 null)", example = "1") Long voteId,
+        @Schema(description = "투표 제목 (없으면 null)", example = "DDD 13기 최종 투표") String title,
+        @Schema(description = "내가 이미 참여했는지 여부 (true 면 완료 화면 노출)") boolean alreadyResponded) {
+
+    public static ActiveVoteResponse none() {
+        return new ActiveVoteResponse(false, null, null, false);
+    }
+
+    public static ActiveVoteResponse of(final Vote vote, final boolean alreadyResponded) {
+        return new ActiveVoteResponse(true, vote.getId(), vote.getTitle(), alreadyResponded);
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/ActiveVoteResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/ActiveVoteResponse.java
@@ -5,17 +5,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(title = "[투표] 진행 중 투표 조회 응답 DTO")
 public record ActiveVoteResponse(
-        @Schema(description = "진행 중(OPEN) 투표 존재 여부 (false 면 멤버 메뉴에 '투표' 미노출)")
-                boolean hasActiveVote,
-        @Schema(description = "투표 Id (없으면 null)", example = "1") Long voteId,
-        @Schema(description = "투표 제목 (없으면 null)", example = "DDD 13기 최종 투표") String title,
+        @Schema(description = "투표 Id", example = "1") Long voteId,
+        @Schema(description = "투표 제목", example = "DDD 13기 최종 투표") String title,
         @Schema(description = "내가 이미 참여했는지 여부 (true 면 완료 화면 노출)") boolean alreadyResponded) {
 
-    public static ActiveVoteResponse none() {
-        return new ActiveVoteResponse(false, null, null, false);
-    }
-
     public static ActiveVoteResponse of(final Vote vote, final boolean alreadyResponded) {
-        return new ActiveVoteResponse(true, vote.getId(), vote.getTitle(), alreadyResponded);
+        return new ActiveVoteResponse(vote.getId(), vote.getTitle(), alreadyResponded);
     }
 }

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/MyVoteStatusResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/MyVoteStatusResponse.java
@@ -1,0 +1,13 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "[투표] 내 참여 여부 조회 응답 DTO")
+public record MyVoteStatusResponse(
+        @Schema(description = "투표 Id", example = "1") Long voteId,
+        @Schema(description = "내가 이미 참여했는지 여부") boolean responded) {
+
+    public static MyVoteStatusResponse of(final Long voteId, final boolean responded) {
+        return new MyVoteStatusResponse(voteId, responded);
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteNonRespondersResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteNonRespondersResponse.java
@@ -1,0 +1,20 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(title = "[투표] 미참여 멤버 명단 응답 DTO")
+public record VoteNonRespondersResponse(
+        @Schema(description = "미참여 멤버 수", example = "7") int totalCount,
+        @Schema(description = "미참여 멤버 목록") List<NonResponder> members) {
+
+    @Schema(title = "미참여 멤버 항목")
+    public record NonResponder(
+            @Schema(description = "멤버 Id") Long memberId,
+            @Schema(description = "이름", example = "홍길동") String name,
+            @Schema(description = "소속 팀명(미배정 시 null)", example = "iOS 1팀") String teamName) {}
+
+    public static VoteNonRespondersResponse of(final List<NonResponder> members) {
+        return new VoteNonRespondersResponse(members.size(), members);
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteParticipationResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteParticipationResponse.java
@@ -1,0 +1,28 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import com.ddd.manage_attendance.domain.vote.domain.Vote;
+import com.ddd.manage_attendance.domain.vote.domain.VoteStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "[투표] 운영진 투표 관리(상태 + 참여 현황) 응답 DTO")
+public record VoteParticipationResponse(
+        @Schema(description = "투표 Id", example = "1") Long voteId,
+        @Schema(description = "투표 제목", example = "DDD 13기 최종 투표") String title,
+        @Schema(description = "투표 상태 (DRAFT/OPEN/CLOSED)") VoteStatus status,
+        @Schema(description = "대상 멤버 수(운영진 제외)", example = "42") int totalMembers,
+        @Schema(description = "참여한 멤버 수", example = "35") int respondedMembers,
+        @Schema(description = "참여율(%) 정수 반올림", example = "83") int participationRate) {
+
+    public static VoteParticipationResponse of(
+            final Vote vote, final int totalMembers, final int respondedMembers) {
+        final int rate =
+                totalMembers == 0 ? 0 : (int) Math.round((respondedMembers * 100.0) / totalMembers);
+        return new VoteParticipationResponse(
+                vote.getId(),
+                vote.getTitle(),
+                vote.getStatus(),
+                totalMembers,
+                respondedMembers,
+                rate);
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteAnswerValidator.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteAnswerValidator.java
@@ -55,6 +55,7 @@ public class VoteAnswerValidator {
                                         TeamVoteTemplate.Category::id, Function.identity()));
 
         final Set<String> seenCategoryIds = new HashSet<>();
+        final Set<String> answeredCategoryIds = new HashSet<>();
         for (final TeamVoteCategoryAnswer answer : answers) {
             final TeamVoteTemplate.Category category = categories.get(answer.categoryId());
             if (category == null) {
@@ -81,7 +82,20 @@ public class VoteAnswerValidator {
                     throw new VoteAnswerInvalidException("선택할 수 없는 팀입니다: " + teamId);
                 }
             }
-            validateReason(category, answer.reason(), !teamIds.isEmpty());
+
+            final boolean teamSelected = !teamIds.isEmpty();
+            if (teamSelected) {
+                answeredCategoryIds.add(answer.categoryId());
+            }
+            validateReason(category, answer.reason(), teamSelected);
+        }
+
+        // 모든 부문 필수: 템플릿의 각 부문에 1개 이상 팀 선택이 있어야 한다.
+        for (final TeamVoteTemplate.Category category : template.categories()) {
+            if (!answeredCategoryIds.contains(category.id())) {
+                throw new VoteAnswerInvalidException(
+                        "부문 '%s' 의 팀을 1개 이상 선택해주세요.".formatted(category.title()));
+            }
         }
     }
 

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteFacade.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteFacade.java
@@ -5,12 +5,18 @@ import com.ddd.manage_attendance.domain.auth.domain.User;
 import com.ddd.manage_attendance.domain.auth.domain.UserService;
 import com.ddd.manage_attendance.domain.team.domain.Team;
 import com.ddd.manage_attendance.domain.team.domain.TeamService;
+import com.ddd.manage_attendance.domain.vote.api.dto.ActiveVoteResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.FeedbackTemplateResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.MyVoteStatusResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.TeamVoteTemplateResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteCreateRequest;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteNonRespondersResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteParticipationResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteTemplateUpdateRequest;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -92,5 +98,66 @@ public class VoteFacade {
         manager.validateManager();
         final Vote vote = voteService.getVote(voteId);
         vote.close(timeProvider.nowDateTime());
+    }
+
+    /** [멤버] 내 기수의 진행 중(OPEN) 투표 + 내 참여 여부. 홈 메뉴에 '투표' 노출/진입 판단에 사용한다. */
+    @Transactional(readOnly = true)
+    public ActiveVoteResponse getActiveVote(final Long userId) {
+        final User user = userService.getUser(userId);
+        final Optional<Vote> activeVote = voteService.findOpenVote(user.getGenerationId());
+        return activeVote
+                .map(
+                        vote ->
+                                ActiveVoteResponse.of(
+                                        vote, voteService.hasResponded(vote.getId(), userId)))
+                .orElseGet(ActiveVoteResponse::none);
+    }
+
+    /** [멤버] 특정 투표에 내가 이미 참여했는지 조회. 완료/재참여 차단 화면 판단에 사용한다. */
+    @Transactional(readOnly = true)
+    public MyVoteStatusResponse getMyVoteStatus(final Long userId, final Long voteId) {
+        userService.getUser(userId);
+        voteService.getVote(voteId);
+        return MyVoteStatusResponse.of(voteId, voteService.hasResponded(voteId, userId));
+    }
+
+    /** [운영진] 투표 상태 + 참여 현황(대상/참여/참여율). 운영진은 운영진 본인을 제외한 멤버를 모집단으로 본다. */
+    @Transactional(readOnly = true)
+    public VoteParticipationResponse getParticipation(final Long userId, final Long voteId) {
+        final User manager = userService.getUser(userId);
+        manager.validateManager();
+        final Vote vote = voteService.getVote(voteId);
+
+        final List<User> members = userService.findMembersByGeneration(vote.getGenerationId());
+        final Set<Long> respondedIds = voteService.findRespondedMemberIds(voteId);
+        final int respondedMembers =
+                (int) members.stream().filter(m -> respondedIds.contains(m.getId())).count();
+        return VoteParticipationResponse.of(vote, members.size(), respondedMembers);
+    }
+
+    /** [운영진] 미참여 멤버 명단(이름 + 소속 팀명). */
+    @Transactional(readOnly = true)
+    public VoteNonRespondersResponse getNonResponders(final Long userId, final Long voteId) {
+        final User manager = userService.getUser(userId);
+        manager.validateManager();
+        final Vote vote = voteService.getVote(voteId);
+
+        final List<User> members = userService.findMembersByGeneration(vote.getGenerationId());
+        final Set<Long> respondedIds = voteService.findRespondedMemberIds(voteId);
+        final Map<Long, String> teamNameById =
+                teamService.findAllByGenerationId(vote.getGenerationId()).stream()
+                        .collect(Collectors.toMap(Team::getId, Team::getName));
+
+        final List<VoteNonRespondersResponse.NonResponder> nonResponders =
+                members.stream()
+                        .filter(m -> !respondedIds.contains(m.getId()))
+                        .map(
+                                m ->
+                                        new VoteNonRespondersResponse.NonResponder(
+                                                m.getId(),
+                                                m.getName(),
+                                                teamNameById.get(m.getTeamId())))
+                        .toList();
+        return VoteNonRespondersResponse.of(nonResponders);
     }
 }

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteFacade.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteFacade.java
@@ -14,9 +14,10 @@ import com.ddd.manage_attendance.domain.vote.api.dto.VoteNonRespondersResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteParticipationResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteTemplateUpdateRequest;
+import com.ddd.manage_attendance.domain.vote.exception.VoteManagerNotAllowedException;
+import com.ddd.manage_attendance.domain.vote.exception.VoteNoActiveException;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -51,6 +52,9 @@ public class VoteFacade {
     @Transactional
     public void submit(final Long userId, final Long voteId, final VoteSubmitRequest request) {
         final User user = userService.getUser(userId);
+        if (user.isManager()) {
+            throw new VoteManagerNotAllowedException();
+        }
         final Vote vote = voteService.getVote(voteId);
         vote.validateOpen();
 
@@ -100,17 +104,15 @@ public class VoteFacade {
         vote.close(timeProvider.nowDateTime());
     }
 
-    /** [멤버] 내 기수의 진행 중(OPEN) 투표 + 내 참여 여부. 홈 메뉴에 '투표' 노출/진입 판단에 사용한다. */
+    /** [멤버] 내 기수의 진행 중(OPEN) 투표 + 내 참여 여부. 진행 중 투표가 없으면 404. */
     @Transactional(readOnly = true)
     public ActiveVoteResponse getActiveVote(final Long userId) {
         final User user = userService.getUser(userId);
-        final Optional<Vote> activeVote = voteService.findOpenVote(user.getGenerationId());
-        return activeVote
-                .map(
-                        vote ->
-                                ActiveVoteResponse.of(
-                                        vote, voteService.hasResponded(vote.getId(), userId)))
-                .orElseGet(ActiveVoteResponse::none);
+        final Vote vote =
+                voteService
+                        .findOpenVote(user.getGenerationId())
+                        .orElseThrow(VoteNoActiveException::new);
+        return ActiveVoteResponse.of(vote, voteService.hasResponded(vote.getId(), userId));
     }
 
     /** [멤버] 특정 투표에 내가 이미 참여했는지 조회. 완료/재참여 차단 화면 판단에 사용한다. */

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteRepository.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteRepository.java
@@ -1,5 +1,11 @@
 package com.ddd.manage_attendance.domain.vote.domain;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface VoteRepository extends JpaRepository<Vote, Long> {}
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+
+    /** 한 기수에서 특정 상태(예: OPEN)인 가장 최근 투표를 조회한다. 기수당 진행 중 투표는 하나라는 전제. */
+    Optional<Vote> findFirstByGenerationIdAndStatusOrderByIdDesc(
+            Long generationId, VoteStatus status);
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteResponseRepository.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteResponseRepository.java
@@ -1,5 +1,6 @@
 package com.ddd.manage_attendance.domain.vote.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,7 @@ public interface VoteResponseRepository extends JpaRepository<VoteResponse, Long
     Optional<VoteResponse> findByVoteIdAndMemberId(Long voteId, Long memberId);
 
     boolean existsByVoteIdAndMemberId(Long voteId, Long memberId);
+
+    /** 특정 투표의 모든 응답 행. 참여 현황/미참여 명단 집계에 사용한다. */
+    List<VoteResponse> findAllByVoteId(Long voteId);
 }

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteService.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteService.java
@@ -9,6 +9,9 @@ import com.ddd.manage_attendance.domain.vote.exception.VoteAlreadyRespondedExcep
 import com.ddd.manage_attendance.domain.vote.exception.VoteNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -28,6 +31,27 @@ public class VoteService {
     @Transactional(readOnly = true)
     public Vote getVote(final Long voteId) {
         return voteRepository.findById(voteId).orElseThrow(VoteNotFoundException::new);
+    }
+
+    /** 기수의 진행 중(OPEN) 투표. 멤버 메뉴 노출/진입 판단에 사용한다. */
+    @Transactional(readOnly = true)
+    public Optional<Vote> findOpenVote(final Long generationId) {
+        return voteRepository.findFirstByGenerationIdAndStatusOrderByIdDesc(
+                generationId, VoteStatus.OPEN);
+    }
+
+    /** 멤버가 해당 투표에 이미 응답했는지 여부. */
+    @Transactional(readOnly = true)
+    public boolean hasResponded(final Long voteId, final Long memberId) {
+        return voteResponseRepository.existsByVoteIdAndMemberId(voteId, memberId);
+    }
+
+    /** 해당 투표에 응답한 멤버 Id 집합. 참여 현황/미참여 명단 집계에 사용한다. */
+    @Transactional(readOnly = true)
+    public Set<Long> findRespondedMemberIds(final Long voteId) {
+        return voteResponseRepository.findAllByVoteId(voteId).stream()
+                .map(VoteResponse::getMemberId)
+                .collect(Collectors.toSet());
     }
 
     @Transactional

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteManagerNotAllowedException.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteManagerNotAllowedException.java
@@ -1,0 +1,11 @@
+package com.ddd.manage_attendance.domain.vote.exception;
+
+import com.ddd.manage_attendance.core.exception.BaseException;
+import com.ddd.manage_attendance.core.exception.ErrorCode;
+
+public class VoteManagerNotAllowedException extends BaseException {
+
+    public VoteManagerNotAllowedException() {
+        super(ErrorCode.VOTE_MANAGER_NOT_ALLOWED);
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteNoActiveException.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteNoActiveException.java
@@ -1,0 +1,11 @@
+package com.ddd.manage_attendance.domain.vote.exception;
+
+import com.ddd.manage_attendance.core.exception.BaseException;
+import com.ddd.manage_attendance.core.exception.ErrorCode;
+
+public class VoteNoActiveException extends BaseException {
+
+    public VoteNoActiveException() {
+        super(ErrorCode.VOTE_NO_ACTIVE);
+    }
+}

--- a/src/test/java/com/ddd/manage_attendance/domain/vote/domain/VoteAnswerValidatorTest.java
+++ b/src/test/java/com/ddd/manage_attendance/domain/vote/domain/VoteAnswerValidatorTest.java
@@ -212,7 +212,25 @@ class VoteAnswerValidatorTest {
     @Test
     @DisplayName("필수 피드백 질문에 응답하지 않으면 예외가 발생한다")
     void requiredFeedbackMissing_throws() {
-        final VoteSubmitRequest request = request(List.of(), List.of());
+        final VoteSubmitRequest request =
+                request(
+                        List.of(new TeamVoteCategoryAnswer("PLANNING", List.of(11L), "기획이 탄탄했어요")),
+                        List.of());
+
+        assertThatThrownBy(
+                        () ->
+                                validator.validate(
+                                        voteWithTemplates(), OWN_TEAM_ID, VALID_TEAM_IDS, request))
+                .isInstanceOf(VoteAnswerInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("팀 투표 부문에 팀을 선택하지 않으면 예외가 발생한다")
+    void teamCategoryNotSelected_throws() {
+        final VoteSubmitRequest request =
+                request(
+                        List.of(),
+                        List.of(new FeedbackQuestionAnswer("BEST", List.of("OT"), null, null)));
 
         assertThatThrownBy(
                         () ->


### PR DESCRIPTION
## 개요
PR #68(투표 SDUI) 머지 후, Figma 디자인에는 있으나 백엔드에 누락됐던 **조회/집계 API**를 추가하고, 코드 리뷰에서 발견한 갭을 반영했습니다.

스키마 변경 없는 **읽기 전용 조회 API** 위주라 신규 DDL은 불필요합니다(운영진 제출 차단·부문 필수 강제는 검증 로직 변경).

## 추가된 API (`eb75639`)
| 메서드 | 엔드포인트 | 대상 | 디자인 화면 |
|---|---|---|---|
| GET | `/api/votes/active` | 멤버 | 홈 '투표(NEW)' 노출/진입 (없으면 404) |
| GET | `/api/votes/{voteId}/responses/me` | 멤버 | 완료/재참여 차단 |
| GET | `/api/votes/{voteId}/participation` | 운영진 | 투표 관리(상태 + 참여현황 N명/N%) |
| GET | `/api/votes/{voteId}/non-responders` | 운영진 | 미참여 명단(이름+팀) |

- 참여 모집단은 **운영진 제외(role=MEMBER)** — 기존 출석 현황 선례와 일치
- 운영진 전용 API는 `validateManager()` 권한 체크
- 미참여 명단은 `teamId→name` 맵으로 N+1 회피

## 리뷰 반영 (`2a1d457`)
- **`/active` 404화**: 진행 중 투표 없으면 `404 VOTE_NO_ACTIVE`
- **운영진 제출 차단**: `403 VOTE_MANAGER_NOT_ALLOWED` (설계상 운영진은 투표 대상 아님)
- **팀 투표 부문 필수 강제**: 템플릿의 모든 부문에 팀 1개 이상 선택을 서버에서 검증(기존엔 0개도 통과)
- **에러 응답 정리**: `ErrorResponse.detail`의 스택트레이스 노출 제거(서버 로깅은 유지)
- 검증 단위 테스트 보강(부문 필수)

## 검증
- 단위 테스트: 투표 도메인 테스트 전체 통과(`BUILD SUCCESSFUL`)
- 로컬 E2E(HTTP): 생성→open→active(200/404)→템플릿→제출(부문필수)→내참여여부→재제출차단→참여현황(3명중1명 33%)→미참여명단→운영진제출403 전부 기대대로 확인

## 참고
- 컴포넌트 타입 분기(MULTI_SELECT/LONG_TEXT/BOOLEAN)는 PR #68에서 이미 구현되어 있음(`question.type`).
- (후속 권고) `openVote`에 "기수당 OPEN 1개" 가드 추가 시 `/active` 단일성 보장 강화 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)