### PR TITLE
feat: 투표 결과 집계·운영진 조회 API 추가 + OPEN 단일성 가드 (#68/#69 후속)

### DIFF
--- a/src/main/java/com/ddd/manage_attendance/core/exception/ErrorCode.java
+++ b/src/main/java/com/ddd/manage_attendance/core/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     VOTE_ALREADY_RESPONDED(HttpStatus.BAD_REQUEST, "이미 투표에 참여했습니다."),
     VOTE_NO_ACTIVE(HttpStatus.NOT_FOUND, "진행 중인 투표가 없습니다."),
     VOTE_MANAGER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "운영진은 투표에 참여할 수 없습니다."),
+    VOTE_ALREADY_OPEN(HttpStatus.CONFLICT, "이미 진행 중인 투표가 있습니다."),
 
     // 데이터 관련
     DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 데이터입니다."),

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/VoteController.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/VoteController.java
@@ -1,19 +1,24 @@
 package com.ddd.manage_attendance.domain.vote.api;
 
 import com.ddd.manage_attendance.domain.vote.api.dto.ActiveVoteResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.FeedbackResultResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.FeedbackTemplateResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.MyVoteStatusResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.TeamVoteResultResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.TeamVoteTemplateResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteCreateRequest;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteCreateResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteDetailResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteNonRespondersResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteParticipationResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteSummaryResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteTemplateUpdateRequest;
 import com.ddd.manage_attendance.domain.vote.domain.VoteFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -45,6 +50,25 @@ public class VoteController {
             @RequestBody final VoteCreateRequest request) {
         final Long voteId = voteFacade.createVote(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(VoteCreateResponse.from(voteId));
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "[운영진] 투표 목록 조회",
+            description = "본인 기수의 전체 투표를 최신순으로 조회합니다.\n\n- 운영진 권한 필수")
+    @SecurityRequirement(name = "JWT")
+    public List<VoteSummaryResponse> getVotes(@AuthenticationPrincipal final Long userId) {
+        return voteFacade.getVotesForManager(userId);
+    }
+
+    @GetMapping("/{voteId}")
+    @Operation(
+            summary = "[운영진] 투표 상세 조회",
+            description = "투표 상태와 팀 투표/피드백 템플릿을 함께 조회합니다(편집 재개용).\n\n- 운영진 권한 필수")
+    @SecurityRequirement(name = "JWT")
+    public VoteDetailResponse getVoteDetail(
+            @AuthenticationPrincipal final Long userId, @PathVariable final Long voteId) {
+        return voteFacade.getVoteDetail(userId, voteId);
     }
 
     @PutMapping("/{voteId}/template")
@@ -95,6 +119,32 @@ public class VoteController {
     public FeedbackTemplateResponse getFeedbackTemplate(
             @AuthenticationPrincipal final Long userId, @PathVariable final Long voteId) {
         return voteFacade.getFeedbackTemplate(userId, voteId);
+    }
+
+    @GetMapping("/{voteId}/team-vote/results")
+    @Operation(
+            summary = "[운영진] 팀 투표 결과 집계 조회",
+            description =
+                    "부문별 팀 득표 순위와 작성된 사유 목록을 조회합니다.\n\n"
+                            + "- 운영진 권한 필수\n"
+                            + "- OPEN/CLOSED 모두 실시간 집계(DRAFT 는 빈 결과)")
+    @SecurityRequirement(name = "JWT")
+    public TeamVoteResultResponse getTeamVoteResults(
+            @AuthenticationPrincipal final Long userId, @PathVariable final Long voteId) {
+        return voteFacade.getTeamVoteResults(userId, voteId);
+    }
+
+    @GetMapping("/{voteId}/feedback/results")
+    @Operation(
+            summary = "[운영진] 참여 경험 피드백 결과 집계 조회",
+            description =
+                    "질문별 응답 분포(선택지/예·아니오)와 작성 텍스트(익명)를 조회합니다.\n\n"
+                            + "- 운영진 권한 필수\n"
+                            + "- followUp 후속 질문도 함께 집계")
+    @SecurityRequirement(name = "JWT")
+    public FeedbackResultResponse getFeedbackResults(
+            @AuthenticationPrincipal final Long userId, @PathVariable final Long voteId) {
+        return voteFacade.getFeedbackResults(userId, voteId);
     }
 
     @PostMapping("/{voteId}/responses")

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/FeedbackResultResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/FeedbackResultResponse.java
@@ -1,0 +1,171 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import com.ddd.manage_attendance.core.sdui.FeedbackTemplate;
+import com.ddd.manage_attendance.core.sdui.VoteComponentType;
+import com.ddd.manage_attendance.domain.vote.domain.FeedbackBoolTally;
+import com.ddd.manage_attendance.domain.vote.domain.FeedbackOptionTally;
+import com.ddd.manage_attendance.domain.vote.domain.FeedbackTextView;
+import com.ddd.manage_attendance.domain.vote.domain.Vote;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * [운영진] 참여 경험 피드백 결과 집계 응답. 질문 타입에 따라 집계 형태가 다르다.
+ *
+ * <ul>
+ *   <li>MULTI_SELECT — 템플릿의 모든 선택지를 0 포함 분포로 노출
+ *   <li>BOOLEAN — 예/아니오 응답 수
+ *   <li>LONG_TEXT — 작성된 텍스트 목록(익명)
+ * </ul>
+ *
+ * <p>followUp(중첩 후속 질문)도 응답 대상이므로 평탄화하여 함께 집계한다.
+ */
+@Schema(title = "[투표] 참여 경험 피드백 결과 집계 응답 DTO")
+public record FeedbackResultResponse(
+        @Schema(description = "투표 Id", example = "1") Long voteId,
+        @Schema(description = "총 응답자 수", example = "35") long totalResponses,
+        @Schema(description = "질문별 결과(followUp 포함, 템플릿 order 순)") List<QuestionResult> questions) {
+
+    @Schema(title = "질문별 결과")
+    public record QuestionResult(
+            @Schema(description = "질문 Id") String questionId,
+            @Schema(description = "질문 제목") String title,
+            @Schema(description = "컴포넌트 타입") VoteComponentType type,
+            @Schema(description = "노출 순서") int order,
+            @Schema(description = "선택지별 응답 수(MULTI_SELECT, 그 외 null)") List<OptionResult> options,
+            @Schema(description = "예 응답 수(BOOLEAN, 그 외 null)") Long trueCount,
+            @Schema(description = "아니오 응답 수(BOOLEAN, 그 외 null)") Long falseCount,
+            @Schema(description = "작성 응답 목록(LONG_TEXT, 그 외 null)") List<String> textAnswers) {}
+
+    @Schema(title = "선택지별 응답 수")
+    public record OptionResult(
+            @Schema(description = "선택지 Id") String optionId,
+            @Schema(description = "선택지 라벨") String label,
+            @Schema(description = "응답 수") long count) {}
+
+    public static FeedbackResultResponse of(
+            final Vote vote,
+            final List<FeedbackOptionTally> optionTallies,
+            final List<FeedbackBoolTally> boolTallies,
+            final List<FeedbackTextView> texts,
+            final long totalResponses) {
+        final Map<String, Map<String, Long>> optionCount =
+                optionTallies.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        FeedbackOptionTally::questionId,
+                                        Collectors.toMap(
+                                                FeedbackOptionTally::optionId,
+                                                FeedbackOptionTally::count)));
+        final Map<String, Map<Boolean, Long>> boolCount =
+                boolTallies.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        FeedbackBoolTally::questionId,
+                                        Collectors.toMap(
+                                                FeedbackBoolTally::boolValue,
+                                                FeedbackBoolTally::count)));
+        final Map<String, List<String>> textsByQuestion =
+                texts.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        FeedbackTextView::questionId,
+                                        Collectors.mapping(
+                                                FeedbackTextView::textValue, Collectors.toList())));
+
+        final FeedbackTemplate template = vote.getFeedbackTemplate();
+        final List<QuestionResult> questions =
+                template == null
+                        ? List.of()
+                        : flatten(template.questions()).stream()
+                                .map(
+                                        question ->
+                                                toResult(
+                                                        question,
+                                                        optionCount,
+                                                        boolCount,
+                                                        textsByQuestion))
+                                .filter(Objects::nonNull)
+                                .toList();
+        return new FeedbackResultResponse(vote.getId(), totalResponses, questions);
+    }
+
+    private static QuestionResult toResult(
+            final FeedbackTemplate.Question question,
+            final Map<String, Map<String, Long>> optionCount,
+            final Map<String, Map<Boolean, Long>> boolCount,
+            final Map<String, List<String>> textsByQuestion) {
+        return switch (question.type()) {
+            case MULTI_SELECT ->
+                    new QuestionResult(
+                            question.id(),
+                            question.title(),
+                            question.type(),
+                            question.order(),
+                            options(question, optionCount.getOrDefault(question.id(), Map.of())),
+                            null,
+                            null,
+                            null);
+            case BOOLEAN -> {
+                final Map<Boolean, Long> counts = boolCount.getOrDefault(question.id(), Map.of());
+                yield new QuestionResult(
+                        question.id(),
+                        question.title(),
+                        question.type(),
+                        question.order(),
+                        null,
+                        counts.getOrDefault(Boolean.TRUE, 0L),
+                        counts.getOrDefault(Boolean.FALSE, 0L),
+                        null);
+            }
+            case LONG_TEXT ->
+                    new QuestionResult(
+                            question.id(),
+                            question.title(),
+                            question.type(),
+                            question.order(),
+                            null,
+                            null,
+                            null,
+                            textsByQuestion.getOrDefault(question.id(), List.of()));
+            case TEAM_SELECT -> null;
+        };
+    }
+
+    private static List<OptionResult> options(
+            final FeedbackTemplate.Question question, final Map<String, Long> counts) {
+        if (question.options() == null) {
+            return List.of();
+        }
+        return question.options().stream()
+                .map(
+                        option ->
+                                new OptionResult(
+                                        option.id(),
+                                        option.label(),
+                                        counts.getOrDefault(option.id(), 0L)))
+                .toList();
+    }
+
+    private static List<FeedbackTemplate.Question> flatten(
+            final List<FeedbackTemplate.Question> questions) {
+        final List<FeedbackTemplate.Question> flat = new ArrayList<>();
+        questions.stream()
+                .sorted(Comparator.comparingInt(FeedbackTemplate.Question::order))
+                .forEach(question -> appendWithFollowUps(question, flat));
+        return flat;
+    }
+
+    private static void appendWithFollowUps(
+            final FeedbackTemplate.Question question, final List<FeedbackTemplate.Question> flat) {
+        flat.add(question);
+        if (question.followUp() != null) {
+            appendWithFollowUps(question.followUp(), flat);
+        }
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/TeamVoteResultResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/TeamVoteResultResponse.java
@@ -1,0 +1,106 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import com.ddd.manage_attendance.core.sdui.TeamVoteTemplate;
+import com.ddd.manage_attendance.domain.team.domain.Team;
+import com.ddd.manage_attendance.domain.vote.domain.TeamReasonView;
+import com.ddd.manage_attendance.domain.vote.domain.TeamVoteTally;
+import com.ddd.manage_attendance.domain.vote.domain.Vote;
+import com.ddd.manage_attendance.domain.vote.domain.VoteStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * [운영진] 팀 투표 결과 집계 응답. 정규화된 집계 행({@link TeamVoteTally}/{@link TeamReasonView})을 투표가 보유한 불변 템플릿의 부문
+ * 메타(제목/순서)와 머지한다. 부문은 템플릿 순서대로, 팀은 득표수 내림차순으로 노출한다.
+ */
+@Schema(title = "[투표] 팀 투표 결과 집계 응답 DTO")
+public record TeamVoteResultResponse(
+        @Schema(description = "투표 Id", example = "1") Long voteId,
+        @Schema(description = "투표 제목", example = "DDD 13기 최종 투표") String title,
+        @Schema(description = "투표 상태 (DRAFT/OPEN/CLOSED)") VoteStatus status,
+        @Schema(description = "총 응답자 수", example = "35") long totalResponses,
+        @Schema(description = "부문별 결과(템플릿 order 순)") List<CategoryResult> categories) {
+
+    @Schema(title = "부문별 결과")
+    public record CategoryResult(
+            @Schema(description = "부문 Id") String categoryId,
+            @Schema(description = "부문명", example = "기획 완성도") String title,
+            @Schema(description = "노출 순서") int order,
+            @Schema(description = "팀별 득표(득표수 내림차순)") List<TeamResult> teams,
+            @Schema(description = "작성된 사유 목록(익명)") List<String> reasons) {}
+
+    @Schema(title = "팀별 득표")
+    public record TeamResult(
+            @Schema(description = "순위(1부터, 득표수 내림차순)") int rank,
+            @Schema(description = "팀 Id") Long teamId,
+            @Schema(description = "팀명", example = "iOS 1팀") String name,
+            @Schema(description = "서비스명", example = "PICKFLOW") String serviceName,
+            @Schema(description = "득표수") long voteCount) {}
+
+    public static TeamVoteResultResponse of(
+            final Vote vote,
+            final List<Team> teams,
+            final List<TeamVoteTally> tallies,
+            final List<TeamReasonView> reasons,
+            final long totalResponses) {
+        final Map<Long, Team> teamById =
+                teams.stream().collect(Collectors.toMap(Team::getId, Function.identity()));
+        final Map<String, List<TeamVoteTally>> talliesByCategory =
+                tallies.stream().collect(Collectors.groupingBy(TeamVoteTally::categoryId));
+        final Map<String, List<String>> reasonsByCategory =
+                reasons.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        TeamReasonView::categoryId,
+                                        Collectors.mapping(
+                                                TeamReasonView::reason, Collectors.toList())));
+
+        final TeamVoteTemplate template = vote.getTeamVoteTemplate();
+        final List<CategoryResult> categories =
+                template == null
+                        ? List.of()
+                        : template.categories().stream()
+                                .sorted(Comparator.comparingInt(TeamVoteTemplate.Category::order))
+                                .map(
+                                        category ->
+                                                new CategoryResult(
+                                                        category.id(),
+                                                        category.title(),
+                                                        category.order(),
+                                                        rank(
+                                                                talliesByCategory.getOrDefault(
+                                                                        category.id(), List.of()),
+                                                                teamById),
+                                                        reasonsByCategory.getOrDefault(
+                                                                category.id(), List.of())))
+                                .toList();
+        return new TeamVoteResultResponse(
+                vote.getId(), vote.getTitle(), vote.getStatus(), totalResponses, categories);
+    }
+
+    private static List<TeamResult> rank(
+            final List<TeamVoteTally> categoryTallies, final Map<Long, Team> teamById) {
+        final List<TeamVoteTally> sorted =
+                categoryTallies.stream()
+                        .sorted(Comparator.comparingLong(TeamVoteTally::voteCount).reversed())
+                        .toList();
+        final List<TeamResult> results = new ArrayList<>();
+        int rank = 1;
+        for (final TeamVoteTally tally : sorted) {
+            final Team team = teamById.get(tally.teamId());
+            results.add(
+                    new TeamResult(
+                            rank++,
+                            tally.teamId(),
+                            team == null ? null : team.getName(),
+                            team == null ? null : team.getServiceName(),
+                            tally.voteCount()));
+        }
+        return results;
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteDetailResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteDetailResponse.java
@@ -1,0 +1,27 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import com.ddd.manage_attendance.core.sdui.FeedbackTemplate;
+import com.ddd.manage_attendance.core.sdui.TeamVoteTemplate;
+import com.ddd.manage_attendance.domain.vote.domain.Vote;
+import com.ddd.manage_attendance.domain.vote.domain.VoteStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "[투표] 운영진 투표 상세(상태 + 양쪽 템플릿) 응답 DTO")
+public record VoteDetailResponse(
+        @Schema(description = "투표 Id", example = "1") Long voteId,
+        @Schema(description = "투표 제목") String title,
+        @Schema(description = "투표 상태 (DRAFT/OPEN/CLOSED)") VoteStatus status,
+        @Schema(description = "템플릿 버전") int templateVersion,
+        @Schema(description = "팀 투표 템플릿(없으면 null)") TeamVoteTemplate teamVoteTemplate,
+        @Schema(description = "참여 경험 피드백 템플릿(없으면 null)") FeedbackTemplate feedbackTemplate) {
+
+    public static VoteDetailResponse from(final Vote vote) {
+        return new VoteDetailResponse(
+                vote.getId(),
+                vote.getTitle(),
+                vote.getStatus(),
+                vote.getTemplateVersion(),
+                vote.getTeamVoteTemplate(),
+                vote.getFeedbackTemplate());
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteSummaryResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteSummaryResponse.java
@@ -1,0 +1,31 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import com.ddd.manage_attendance.domain.vote.domain.Vote;
+import com.ddd.manage_attendance.domain.vote.domain.VoteStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(title = "[투표] 운영진 투표 목록 항목 응답 DTO")
+public record VoteSummaryResponse(
+        @Schema(description = "투표 Id", example = "1") Long voteId,
+        @Schema(description = "투표 제목", example = "DDD 13기 최종 투표") String title,
+        @Schema(description = "투표 상태 (DRAFT/OPEN/CLOSED)") VoteStatus status,
+        @Schema(description = "투표 시작 시각(미시작 시 null)") LocalDateTime openedAt,
+        @Schema(description = "투표 종료 시각(미종료 시 null)") LocalDateTime closedAt,
+        @Schema(description = "생성 일자") LocalDateTime createdDate) {
+
+    public static VoteSummaryResponse from(final Vote vote) {
+        return new VoteSummaryResponse(
+                vote.getId(),
+                vote.getTitle(),
+                vote.getStatus(),
+                vote.getOpenedAt(),
+                vote.getClosedAt(),
+                vote.getCreatedDate());
+    }
+
+    public static List<VoteSummaryResponse> fromList(final List<Vote> votes) {
+        return votes.stream().map(VoteSummaryResponse::from).toList();
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/FeedbackAnswerRepository.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/FeedbackAnswerRepository.java
@@ -2,8 +2,46 @@ package com.ddd.manage_attendance.domain.vote.domain;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FeedbackAnswerRepository extends JpaRepository<FeedbackAnswer, Long> {
 
     List<FeedbackAnswer> findByResponseId(Long responseId);
+
+    /** MULTI_SELECT 선택지별 응답 수 집계. */
+    @Query(
+            """
+            SELECT new com.ddd.manage_attendance.domain.vote.domain.FeedbackOptionTally(
+                f.questionId, f.optionId, COUNT(f))
+            FROM FeedbackAnswer f
+            JOIN VoteResponse r ON r.id = f.responseId
+            WHERE r.voteId = :voteId AND f.optionId IS NOT NULL
+            GROUP BY f.questionId, f.optionId
+""")
+    List<FeedbackOptionTally> tallyOptionsByVoteId(@Param("voteId") Long voteId);
+
+    /** BOOLEAN 예/아니오 응답 수 집계. */
+    @Query(
+            """
+            SELECT new com.ddd.manage_attendance.domain.vote.domain.FeedbackBoolTally(
+                f.questionId, f.boolValue, COUNT(f))
+            FROM FeedbackAnswer f
+            JOIN VoteResponse r ON r.id = f.responseId
+            WHERE r.voteId = :voteId AND f.boolValue IS NOT NULL
+            GROUP BY f.questionId, f.boolValue
+""")
+    List<FeedbackBoolTally> tallyBoolByVoteId(@Param("voteId") Long voteId);
+
+    /** LONG_TEXT 작성 응답 목록(익명). */
+    @Query(
+            """
+            SELECT new com.ddd.manage_attendance.domain.vote.domain.FeedbackTextView(
+                f.questionId, f.textValue)
+            FROM FeedbackAnswer f
+            JOIN VoteResponse r ON r.id = f.responseId
+            WHERE r.voteId = :voteId AND f.textValue IS NOT NULL
+            ORDER BY f.id
+""")
+    List<FeedbackTextView> findTextsByVoteId(@Param("voteId") Long voteId);
 }

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/FeedbackBoolTally.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/FeedbackBoolTally.java
@@ -1,0 +1,4 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+/** 피드백 BOOLEAN 예/아니오 응답 수 집계. {@code SELECT new ...} 생성자 프로젝션 대상. */
+public record FeedbackBoolTally(String questionId, Boolean boolValue, Long count) {}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/FeedbackOptionTally.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/FeedbackOptionTally.java
@@ -1,0 +1,4 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+/** 피드백 MULTI_SELECT 선택지별 응답 수 집계. {@code SELECT new ...} 생성자 프로젝션 대상. */
+public record FeedbackOptionTally(String questionId, String optionId, Long count) {}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/FeedbackTextView.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/FeedbackTextView.java
@@ -1,0 +1,4 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+/** 피드백 LONG_TEXT 작성 응답(익명). {@code SELECT new ...} 생성자 프로젝션 대상. */
+public record FeedbackTextView(String questionId, String textValue) {}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamReasonView.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamReasonView.java
@@ -1,0 +1,4 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+/** 팀 투표 부문별 작성 사유(익명). {@code SELECT new ...} 생성자 프로젝션 대상. */
+public record TeamReasonView(String categoryId, String reason) {}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteAnswerRepository.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteAnswerRepository.java
@@ -2,8 +2,22 @@ package com.ddd.manage_attendance.domain.vote.domain;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TeamVoteAnswerRepository extends JpaRepository<TeamVoteAnswer, Long> {
 
     List<TeamVoteAnswer> findByResponseId(Long responseId);
+
+    /** 부문별 팀 득표 집계. response_id 로 {@link VoteResponse} 와 조인해 해당 투표의 응답만 센다. */
+    @Query(
+            """
+            SELECT new com.ddd.manage_attendance.domain.vote.domain.TeamVoteTally(
+                a.categoryId, a.teamId, COUNT(a))
+            FROM TeamVoteAnswer a
+            JOIN VoteResponse r ON r.id = a.responseId
+            WHERE r.voteId = :voteId
+            GROUP BY a.categoryId, a.teamId
+""")
+    List<TeamVoteTally> tallyByVoteId(@Param("voteId") Long voteId);
 }

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteReasonRepository.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteReasonRepository.java
@@ -2,8 +2,22 @@ package com.ddd.manage_attendance.domain.vote.domain;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TeamVoteReasonRepository extends JpaRepository<TeamVoteReason, Long> {
 
     List<TeamVoteReason> findByResponseId(Long responseId);
+
+    /** 부문별 작성 사유 목록(익명). 결과 화면에서 운영진이 사유를 검토하는 데 사용한다. */
+    @Query(
+            """
+            SELECT new com.ddd.manage_attendance.domain.vote.domain.TeamReasonView(
+                t.categoryId, t.reason)
+            FROM TeamVoteReason t
+            JOIN VoteResponse r ON r.id = t.responseId
+            WHERE r.voteId = :voteId AND t.reason IS NOT NULL
+            ORDER BY t.id
+""")
+    List<TeamReasonView> findReasonsByVoteId(@Param("voteId") Long voteId);
 }

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteTally.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/TeamVoteTally.java
@@ -1,0 +1,4 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+/** 팀 투표 집계 행(부문별 팀 득표수). {@code SELECT new ...} 생성자 프로젝션 대상. */
+public record TeamVoteTally(String categoryId, Long teamId, Long voteCount) {}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteFacade.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteFacade.java
@@ -6,14 +6,19 @@ import com.ddd.manage_attendance.domain.auth.domain.UserService;
 import com.ddd.manage_attendance.domain.team.domain.Team;
 import com.ddd.manage_attendance.domain.team.domain.TeamService;
 import com.ddd.manage_attendance.domain.vote.api.dto.ActiveVoteResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.FeedbackResultResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.FeedbackTemplateResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.MyVoteStatusResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.TeamVoteResultResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.TeamVoteTemplateResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteCreateRequest;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteDetailResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteNonRespondersResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteParticipationResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteSubmitRequest;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteSummaryResponse;
 import com.ddd.manage_attendance.domain.vote.api.dto.VoteTemplateUpdateRequest;
+import com.ddd.manage_attendance.domain.vote.exception.VoteAlreadyOpenException;
 import com.ddd.manage_attendance.domain.vote.exception.VoteManagerNotAllowedException;
 import com.ddd.manage_attendance.domain.vote.exception.VoteNoActiveException;
 import java.util.List;
@@ -93,6 +98,14 @@ public class VoteFacade {
         final User manager = userService.getUser(userId);
         manager.validateManager();
         final Vote vote = voteService.getVote(voteId);
+        // 기수당 OPEN 투표는 하나라는 전제를 보장한다(/active 단일성).
+        // 앱 레벨 가드: 운영진 수동·저빈도 작업이며, MySQL 은 조건부 유니크 인덱스를 지원하지 않아 DB 제약 대신 여기서 막는다.
+        voteService
+                .findOpenVote(vote.getGenerationId())
+                .ifPresent(
+                        open -> {
+                            throw new VoteAlreadyOpenException();
+                        });
         vote.open(timeProvider.nowDateTime());
     }
 
@@ -161,5 +174,51 @@ public class VoteFacade {
                                                 teamNameById.get(m.getTeamId())))
                         .toList();
         return VoteNonRespondersResponse.of(nonResponders);
+    }
+
+    /** [운영진] 팀 투표 결과 집계(부문별 팀 득표 + 작성 사유). 집계 행을 템플릿 부문 메타·팀 정보와 머지한다. */
+    @Transactional(readOnly = true)
+    public TeamVoteResultResponse getTeamVoteResults(final Long userId, final Long voteId) {
+        final User manager = userService.getUser(userId);
+        manager.validateManager();
+        final Vote vote = voteService.getVote(voteId);
+        final List<Team> teams = teamService.findAllByGenerationId(vote.getGenerationId());
+        return TeamVoteResultResponse.of(
+                vote,
+                teams,
+                voteService.tallyTeamVotes(voteId),
+                voteService.findTeamVoteReasons(voteId),
+                voteService.countResponses(voteId));
+    }
+
+    /** [운영진] 참여 경험 피드백 결과 집계(질문 타입별 분포/텍스트). */
+    @Transactional(readOnly = true)
+    public FeedbackResultResponse getFeedbackResults(final Long userId, final Long voteId) {
+        final User manager = userService.getUser(userId);
+        manager.validateManager();
+        final Vote vote = voteService.getVote(voteId);
+        return FeedbackResultResponse.of(
+                vote,
+                voteService.tallyFeedbackOptions(voteId),
+                voteService.tallyFeedbackBooleans(voteId),
+                voteService.findFeedbackTexts(voteId),
+                voteService.countResponses(voteId));
+    }
+
+    /** [운영진] 본인 기수의 투표 목록(최신순). */
+    @Transactional(readOnly = true)
+    public List<VoteSummaryResponse> getVotesForManager(final Long userId) {
+        final User manager = userService.getUser(userId);
+        manager.validateManager();
+        return VoteSummaryResponse.fromList(
+                voteService.findVotesByGeneration(manager.getGenerationId()));
+    }
+
+    /** [운영진] 투표 상세(상태 + 양쪽 템플릿). 편집 재개 화면에 사용한다. */
+    @Transactional(readOnly = true)
+    public VoteDetailResponse getVoteDetail(final Long userId, final Long voteId) {
+        final User manager = userService.getUser(userId);
+        manager.validateManager();
+        return VoteDetailResponse.from(voteService.getVote(voteId));
     }
 }

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteRepository.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteRepository.java
@@ -1,5 +1,6 @@
 package com.ddd.manage_attendance.domain.vote.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,7 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
     /** 한 기수에서 특정 상태(예: OPEN)인 가장 최근 투표를 조회한다. 기수당 진행 중 투표는 하나라는 전제. */
     Optional<Vote> findFirstByGenerationIdAndStatusOrderByIdDesc(
             Long generationId, VoteStatus status);
+
+    /** 한 기수의 전체 투표를 최신순으로 조회한다. 운영진 투표 목록 화면에 사용한다. */
+    List<Vote> findAllByGenerationIdOrderByIdDesc(Long generationId);
 }

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteResponseRepository.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteResponseRepository.java
@@ -1,15 +1,15 @@
 package com.ddd.manage_attendance.domain.vote.domain;
 
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VoteResponseRepository extends JpaRepository<VoteResponse, Long> {
-
-    Optional<VoteResponse> findByVoteIdAndMemberId(Long voteId, Long memberId);
 
     boolean existsByVoteIdAndMemberId(Long voteId, Long memberId);
 
     /** 특정 투표의 모든 응답 행. 참여 현황/미참여 명단 집계에 사용한다. */
     List<VoteResponse> findAllByVoteId(Long voteId);
+
+    /** 특정 투표의 총 응답자 수. 결과 집계의 분모로 사용한다. */
+    long countByVoteId(Long voteId);
 }

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteService.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteService.java
@@ -54,6 +54,48 @@ public class VoteService {
                 .collect(Collectors.toSet());
     }
 
+    /** 한 기수의 전체 투표(최신순). 운영진 투표 목록에 사용한다. */
+    @Transactional(readOnly = true)
+    public List<Vote> findVotesByGeneration(final Long generationId) {
+        return voteRepository.findAllByGenerationIdOrderByIdDesc(generationId);
+    }
+
+    /** 해당 투표의 총 응답자 수. 결과 집계의 분모로 사용한다. */
+    @Transactional(readOnly = true)
+    public long countResponses(final Long voteId) {
+        return voteResponseRepository.countByVoteId(voteId);
+    }
+
+    /** 부문별 팀 득표 집계. */
+    @Transactional(readOnly = true)
+    public List<TeamVoteTally> tallyTeamVotes(final Long voteId) {
+        return teamVoteAnswerRepository.tallyByVoteId(voteId);
+    }
+
+    /** 부문별 작성 사유 목록(익명). */
+    @Transactional(readOnly = true)
+    public List<TeamReasonView> findTeamVoteReasons(final Long voteId) {
+        return teamVoteReasonRepository.findReasonsByVoteId(voteId);
+    }
+
+    /** 피드백 MULTI_SELECT 선택지별 응답 수 집계. */
+    @Transactional(readOnly = true)
+    public List<FeedbackOptionTally> tallyFeedbackOptions(final Long voteId) {
+        return feedbackAnswerRepository.tallyOptionsByVoteId(voteId);
+    }
+
+    /** 피드백 BOOLEAN 예/아니오 응답 수 집계. */
+    @Transactional(readOnly = true)
+    public List<FeedbackBoolTally> tallyFeedbackBooleans(final Long voteId) {
+        return feedbackAnswerRepository.tallyBoolByVoteId(voteId);
+    }
+
+    /** 피드백 LONG_TEXT 작성 응답 목록(익명). */
+    @Transactional(readOnly = true)
+    public List<FeedbackTextView> findFeedbackTexts(final Long voteId) {
+        return feedbackAnswerRepository.findTextsByVoteId(voteId);
+    }
+
     @Transactional
     public Vote createDraft(
             final Long generationId,

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteAlreadyOpenException.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteAlreadyOpenException.java
@@ -1,0 +1,11 @@
+package com.ddd.manage_attendance.domain.vote.exception;
+
+import com.ddd.manage_attendance.core.exception.BaseException;
+import com.ddd.manage_attendance.core.exception.ErrorCode;
+
+public class VoteAlreadyOpenException extends BaseException {
+
+    public VoteAlreadyOpenException() {
+        super(ErrorCode.VOTE_ALREADY_OPEN);
+    }
+}

--- a/src/test/java/com/ddd/manage_attendance/domain/vote/api/dto/FeedbackResultResponseTest.java
+++ b/src/test/java/com/ddd/manage_attendance/domain/vote/api/dto/FeedbackResultResponseTest.java
@@ -1,0 +1,141 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddd.manage_attendance.core.sdui.FeedbackTemplate;
+import com.ddd.manage_attendance.core.sdui.VoteComponentType;
+import com.ddd.manage_attendance.domain.vote.domain.FeedbackBoolTally;
+import com.ddd.manage_attendance.domain.vote.domain.FeedbackOptionTally;
+import com.ddd.manage_attendance.domain.vote.domain.FeedbackTextView;
+import com.ddd.manage_attendance.domain.vote.domain.Vote;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FeedbackResultResponseTest {
+
+    private static final Long GENERATION_ID = 13L;
+
+    private Vote voteWith(final FeedbackTemplate template) {
+        return Vote.createDraft(GENERATION_ID, "투표", null, template);
+    }
+
+    @Test
+    @DisplayName("MULTI_SELECT 은 템플릿의 모든 선택지를 0 포함 분포로 집계한다")
+    void of_multiSelect_includesAllOptionsWithZero() {
+        final FeedbackTemplate.Question question =
+                new FeedbackTemplate.Question(
+                        "q1",
+                        1,
+                        VoteComponentType.MULTI_SELECT,
+                        "만족한 요소",
+                        null,
+                        true,
+                        2,
+                        null,
+                        List.of(
+                                new FeedbackTemplate.Option("o1", "속도"),
+                                new FeedbackTemplate.Option("o2", "안정성")),
+                        null);
+        final Vote vote = voteWith(new FeedbackTemplate("피드백", null, List.of(question)));
+        final List<FeedbackOptionTally> options = List.of(new FeedbackOptionTally("q1", "o1", 4L));
+
+        final FeedbackResultResponse response =
+                FeedbackResultResponse.of(vote, options, List.of(), List.of(), 4L);
+
+        final FeedbackResultResponse.QuestionResult result = response.questions().get(0);
+        assertThat(result.type()).isEqualTo(VoteComponentType.MULTI_SELECT);
+        assertThat(result.options())
+                .extracting(FeedbackResultResponse.OptionResult::optionId)
+                .containsExactly("o1", "o2");
+        assertThat(result.options().get(0).count()).isEqualTo(4L);
+        assertThat(result.options().get(1).count()).isZero();
+        assertThat(result.trueCount()).isNull();
+        assertThat(result.textAnswers()).isNull();
+    }
+
+    @Test
+    @DisplayName("BOOLEAN 은 예/아니오 응답 수를 각각 집계한다")
+    void of_boolean_countsTrueAndFalse() {
+        final FeedbackTemplate.Question question =
+                new FeedbackTemplate.Question(
+                        "q1",
+                        1,
+                        VoteComponentType.BOOLEAN,
+                        "추천 여부",
+                        null,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null);
+        final Vote vote = voteWith(new FeedbackTemplate("피드백", null, List.of(question)));
+        final List<FeedbackBoolTally> bools =
+                List.of(
+                        new FeedbackBoolTally("q1", Boolean.TRUE, 7L),
+                        new FeedbackBoolTally("q1", Boolean.FALSE, 3L));
+
+        final FeedbackResultResponse response =
+                FeedbackResultResponse.of(vote, List.of(), bools, List.of(), 10L);
+
+        final FeedbackResultResponse.QuestionResult result = response.questions().get(0);
+        assertThat(result.trueCount()).isEqualTo(7L);
+        assertThat(result.falseCount()).isEqualTo(3L);
+        assertThat(result.options()).isNull();
+    }
+
+    @Test
+    @DisplayName("LONG_TEXT 는 작성된 텍스트 목록을 반환하고 followUp 질문도 평탄화해 함께 집계한다")
+    void of_longText_andFollowUpFlattened() {
+        final FeedbackTemplate.Question followUp =
+                new FeedbackTemplate.Question(
+                        "q1f",
+                        2,
+                        VoteComponentType.LONG_TEXT,
+                        "그 이유는?",
+                        null,
+                        false,
+                        null,
+                        500,
+                        null,
+                        null);
+        final FeedbackTemplate.Question question =
+                new FeedbackTemplate.Question(
+                        "q1",
+                        1,
+                        VoteComponentType.BOOLEAN,
+                        "추천 여부",
+                        null,
+                        false,
+                        null,
+                        null,
+                        null,
+                        followUp);
+        final Vote vote = voteWith(new FeedbackTemplate("피드백", null, List.of(question)));
+        final List<FeedbackTextView> texts =
+                List.of(new FeedbackTextView("q1f", "좋았어요"), new FeedbackTextView("q1f", "최고였습니다"));
+        final List<FeedbackBoolTally> bools =
+                List.of(new FeedbackBoolTally("q1", Boolean.TRUE, 5L));
+
+        final FeedbackResultResponse response =
+                FeedbackResultResponse.of(vote, List.of(), bools, texts, 5L);
+
+        assertThat(response.questions())
+                .extracting(FeedbackResultResponse.QuestionResult::questionId)
+                .containsExactly("q1", "q1f");
+        final FeedbackResultResponse.QuestionResult followUpResult = response.questions().get(1);
+        assertThat(followUpResult.type()).isEqualTo(VoteComponentType.LONG_TEXT);
+        assertThat(followUpResult.textAnswers()).containsExactly("좋았어요", "최고였습니다");
+    }
+
+    @Test
+    @DisplayName("피드백 템플릿이 없으면 빈 질문 목록을 반환한다")
+    void of_whenNoTemplate_returnsEmptyQuestions() {
+        final Vote vote = voteWith(null);
+
+        final FeedbackResultResponse response =
+                FeedbackResultResponse.of(vote, List.of(), List.of(), List.of(), 0L);
+
+        assertThat(response.questions()).isEmpty();
+    }
+}

--- a/src/test/java/com/ddd/manage_attendance/domain/vote/api/dto/TeamVoteResultResponseTest.java
+++ b/src/test/java/com/ddd/manage_attendance/domain/vote/api/dto/TeamVoteResultResponseTest.java
@@ -1,0 +1,88 @@
+package com.ddd.manage_attendance.domain.vote.api.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddd.manage_attendance.core.sdui.TeamVoteTemplate;
+import com.ddd.manage_attendance.domain.team.domain.Team;
+import com.ddd.manage_attendance.domain.vote.domain.TeamReasonView;
+import com.ddd.manage_attendance.domain.vote.domain.TeamVoteTally;
+import com.ddd.manage_attendance.domain.vote.domain.Vote;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class TeamVoteResultResponseTest {
+
+    private static final Long GENERATION_ID = 13L;
+
+    private Team team(final Long id, final String name, final String serviceName) {
+        final Team team = Team.createTeam(name, GENERATION_ID, serviceName);
+        ReflectionTestUtils.setField(team, "id", id);
+        return team;
+    }
+
+    private TeamVoteTemplate singleCategoryTemplate() {
+        return new TeamVoteTemplate(
+                "팀 투표",
+                null,
+                null,
+                List.of(new TeamVoteTemplate.Category("c1", 1, "기획 완성도", 2, false, 0, 500, "이유")));
+    }
+
+    @Test
+    @DisplayName("부문별 팀 득표를 득표수 내림차순으로 순위 매겨 반환하고 사유를 매핑한다")
+    void of_ranksTeamsByVoteCountDescAndMapsReasons() {
+        final Vote vote = Vote.createDraft(GENERATION_ID, "최종 투표", singleCategoryTemplate(), null);
+        final Team teamA = team(100L, "A팀", "서비스A");
+        final Team teamB = team(101L, "B팀", "서비스B");
+        final List<TeamVoteTally> tallies =
+                List.of(new TeamVoteTally("c1", 100L, 3L), new TeamVoteTally("c1", 101L, 5L));
+        final List<TeamReasonView> reasons = List.of(new TeamReasonView("c1", "잘했어요"));
+
+        final TeamVoteResultResponse response =
+                TeamVoteResultResponse.of(vote, List.of(teamA, teamB), tallies, reasons, 8L);
+
+        assertThat(response.totalResponses()).isEqualTo(8L);
+        assertThat(response.categories()).hasSize(1);
+
+        final TeamVoteResultResponse.CategoryResult category = response.categories().get(0);
+        assertThat(category.categoryId()).isEqualTo("c1");
+        assertThat(category.teams())
+                .extracting(TeamVoteResultResponse.TeamResult::teamId)
+                .containsExactly(101L, 100L);
+        assertThat(category.teams().get(0).rank()).isEqualTo(1);
+        assertThat(category.teams().get(0).name()).isEqualTo("B팀");
+        assertThat(category.teams().get(0).serviceName()).isEqualTo("서비스B");
+        assertThat(category.teams().get(0).voteCount()).isEqualTo(5L);
+        assertThat(category.teams().get(1).rank()).isEqualTo(2);
+        assertThat(category.reasons()).containsExactly("잘했어요");
+    }
+
+    @Test
+    @DisplayName("득표가 없는 팀은 결과에서 제외한다")
+    void of_excludesTeamsWithoutVotes() {
+        final Vote vote = Vote.createDraft(GENERATION_ID, "최종 투표", singleCategoryTemplate(), null);
+        final Team teamA = team(100L, "A팀", null);
+        final Team teamB = team(101L, "B팀", null);
+        final List<TeamVoteTally> tallies = List.of(new TeamVoteTally("c1", 100L, 2L));
+
+        final TeamVoteResultResponse response =
+                TeamVoteResultResponse.of(vote, List.of(teamA, teamB), tallies, List.of(), 2L);
+
+        assertThat(response.categories().get(0).teams())
+                .extracting(TeamVoteResultResponse.TeamResult::teamId)
+                .containsExactly(100L);
+    }
+
+    @Test
+    @DisplayName("팀 투표 템플릿이 없으면 빈 부문 목록을 반환한다")
+    void of_whenNoTemplate_returnsEmptyCategories() {
+        final Vote vote = Vote.createDraft(GENERATION_ID, "투표", null, null);
+
+        final TeamVoteResultResponse response =
+                TeamVoteResultResponse.of(vote, List.of(), List.of(), List.of(), 0L);
+
+        assertThat(response.categories()).isEmpty();
+    }
+}

--- a/src/test/java/com/ddd/manage_attendance/domain/vote/domain/VoteFacadeTest.java
+++ b/src/test/java/com/ddd/manage_attendance/domain/vote/domain/VoteFacadeTest.java
@@ -1,0 +1,186 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ddd.manage_attendance.core.util.TimeProvider;
+import com.ddd.manage_attendance.domain.auth.domain.User;
+import com.ddd.manage_attendance.domain.auth.domain.UserService;
+import com.ddd.manage_attendance.domain.team.domain.Team;
+import com.ddd.manage_attendance.domain.team.domain.TeamService;
+import com.ddd.manage_attendance.domain.vote.api.dto.ActiveVoteResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteNonRespondersResponse;
+import com.ddd.manage_attendance.domain.vote.api.dto.VoteParticipationResponse;
+import com.ddd.manage_attendance.domain.vote.exception.VoteAlreadyOpenException;
+import com.ddd.manage_attendance.domain.vote.exception.VoteManagerNotAllowedException;
+import com.ddd.manage_attendance.domain.vote.exception.VoteNoActiveException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class VoteFacadeTest {
+
+    @Mock private VoteService voteService;
+    @Mock private UserService userService;
+    @Mock private TeamService teamService;
+    @Mock private VoteAnswerValidator voteAnswerValidator;
+    @Mock private TimeProvider timeProvider;
+    @InjectMocks private VoteFacade voteFacade;
+
+    private static final Long USER_ID = 1L;
+    private static final Long VOTE_ID = 100L;
+    private static final Long GENERATION_ID = 13L;
+
+    @Test
+    @DisplayName("운영진이 투표를 제출하면 예외가 발생하고 응답은 저장되지 않는다")
+    void submit_whenManager_throws() {
+        final User manager = mock(User.class);
+        given(userService.getUser(USER_ID)).willReturn(manager);
+        given(manager.isManager()).willReturn(true);
+
+        assertThatThrownBy(() -> voteFacade.submit(USER_ID, VOTE_ID, null))
+                .isInstanceOf(VoteManagerNotAllowedException.class);
+        verify(voteService, never()).submitResponse(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("진행 중 투표가 없으면 getActiveVote 는 예외를 던진다")
+    void getActiveVote_whenNoOpen_throws() {
+        final User user = mock(User.class);
+        given(userService.getUser(USER_ID)).willReturn(user);
+        given(user.getGenerationId()).willReturn(GENERATION_ID);
+        given(voteService.findOpenVote(GENERATION_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> voteFacade.getActiveVote(USER_ID))
+                .isInstanceOf(VoteNoActiveException.class);
+    }
+
+    @Test
+    @DisplayName("진행 중 투표가 있으면 참여 여부와 함께 반환한다")
+    void getActiveVote_whenOpen_returns() {
+        final User user = mock(User.class);
+        final Vote vote = Vote.createDraft(GENERATION_ID, "최종 투표", null, null);
+        ReflectionTestUtils.setField(vote, "id", VOTE_ID);
+        given(userService.getUser(USER_ID)).willReturn(user);
+        given(user.getGenerationId()).willReturn(GENERATION_ID);
+        given(voteService.findOpenVote(GENERATION_ID)).willReturn(Optional.of(vote));
+        given(voteService.hasResponded(VOTE_ID, USER_ID)).willReturn(true);
+
+        final ActiveVoteResponse response = voteFacade.getActiveVote(USER_ID);
+
+        assertThat(response.voteId()).isEqualTo(VOTE_ID);
+        assertThat(response.title()).isEqualTo("최종 투표");
+        assertThat(response.alreadyResponded()).isTrue();
+    }
+
+    @Test
+    @DisplayName("같은 기수에 진행 중 투표가 있으면 open 시 예외가 발생하고 상태는 DRAFT 로 유지된다")
+    void openVote_whenAlreadyOpen_throws() {
+        final User manager = mock(User.class);
+        final Vote draft = Vote.createDraft(GENERATION_ID, "새 투표", null, null);
+        given(userService.getUser(USER_ID)).willReturn(manager);
+        given(voteService.getVote(VOTE_ID)).willReturn(draft);
+        given(voteService.findOpenVote(GENERATION_ID)).willReturn(Optional.of(mock(Vote.class)));
+
+        assertThatThrownBy(() -> voteFacade.openVote(USER_ID, VOTE_ID))
+                .isInstanceOf(VoteAlreadyOpenException.class);
+        assertThat(draft.getStatus()).isEqualTo(VoteStatus.DRAFT);
+    }
+
+    @Test
+    @DisplayName("진행 중 투표가 없으면 open 에 성공해 OPEN 으로 전환된다")
+    void openVote_whenNoOpen_success() {
+        final User manager = mock(User.class);
+        final Vote draft = Vote.createDraft(GENERATION_ID, "새 투표", null, null);
+        final LocalDateTime now = LocalDateTime.of(2026, 6, 10, 10, 0);
+        given(userService.getUser(USER_ID)).willReturn(manager);
+        given(voteService.getVote(VOTE_ID)).willReturn(draft);
+        given(voteService.findOpenVote(GENERATION_ID)).willReturn(Optional.empty());
+        given(timeProvider.nowDateTime()).willReturn(now);
+
+        voteFacade.openVote(USER_ID, VOTE_ID);
+
+        assertThat(draft.getStatus()).isEqualTo(VoteStatus.OPEN);
+        assertThat(draft.getOpenedAt()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("참여 현황은 운영진 제외 멤버를 모집단으로 참여율을 계산한다")
+    void getParticipation_computesRateOverMembers() {
+        final User manager = mock(User.class);
+        final Vote vote = Vote.createDraft(GENERATION_ID, "투표", null, null);
+        final User m1 = mock(User.class);
+        final User m2 = mock(User.class);
+        final User m3 = mock(User.class);
+        given(m1.getId()).willReturn(10L);
+        given(m2.getId()).willReturn(11L);
+        given(m3.getId()).willReturn(12L);
+        given(userService.getUser(USER_ID)).willReturn(manager);
+        given(voteService.getVote(VOTE_ID)).willReturn(vote);
+        given(userService.findMembersByGeneration(GENERATION_ID)).willReturn(List.of(m1, m2, m3));
+        given(voteService.findRespondedMemberIds(VOTE_ID)).willReturn(Set.of(10L));
+
+        final VoteParticipationResponse response = voteFacade.getParticipation(USER_ID, VOTE_ID);
+
+        assertThat(response.totalMembers()).isEqualTo(3);
+        assertThat(response.respondedMembers()).isEqualTo(1);
+        assertThat(response.participationRate()).isEqualTo(33);
+    }
+
+    @Test
+    @DisplayName("미참여 명단은 응답하지 않은 멤버만 소속 팀명과 함께 반환한다")
+    void getNonResponders_filtersAndMapsTeamName() {
+        final User manager = mock(User.class);
+        final Vote vote = Vote.createDraft(GENERATION_ID, "투표", null, null);
+        final User responded = mock(User.class);
+        final User pendingWithTeam = mock(User.class);
+        final User pendingNoTeam = mock(User.class);
+        given(responded.getId()).willReturn(10L);
+        given(pendingWithTeam.getId()).willReturn(11L);
+        given(pendingWithTeam.getName()).willReturn("김길동");
+        given(pendingWithTeam.getTeamId()).willReturn(101L);
+        given(pendingNoTeam.getId()).willReturn(12L);
+        given(pendingNoTeam.getName()).willReturn("이몽룡");
+        given(pendingNoTeam.getTeamId()).willReturn(null);
+        final Team teamB = Team.createTeam("B팀", GENERATION_ID);
+        ReflectionTestUtils.setField(teamB, "id", 101L);
+
+        given(userService.getUser(USER_ID)).willReturn(manager);
+        given(voteService.getVote(VOTE_ID)).willReturn(vote);
+        given(userService.findMembersByGeneration(GENERATION_ID))
+                .willReturn(List.of(responded, pendingWithTeam, pendingNoTeam));
+        given(voteService.findRespondedMemberIds(VOTE_ID)).willReturn(Set.of(10L));
+        given(teamService.findAllByGenerationId(GENERATION_ID)).willReturn(List.of(teamB));
+
+        final VoteNonRespondersResponse response = voteFacade.getNonResponders(USER_ID, VOTE_ID);
+
+        assertThat(response.totalCount()).isEqualTo(2);
+        assertThat(response.members())
+                .extracting(VoteNonRespondersResponse.NonResponder::name)
+                .containsExactlyInAnyOrder("김길동", "이몽룡");
+        assertThat(response.members())
+                .filteredOn(r -> r.memberId().equals(11L))
+                .singleElement()
+                .extracting(VoteNonRespondersResponse.NonResponder::teamName)
+                .isEqualTo("B팀");
+        assertThat(response.members())
+                .filteredOn(r -> r.memberId().equals(12L))
+                .singleElement()
+                .extracting(VoteNonRespondersResponse.NonResponder::teamName)
+                .isNull();
+    }
+}

--- a/src/test/java/com/ddd/manage_attendance/domain/vote/domain/VoteServiceTest.java
+++ b/src/test/java/com/ddd/manage_attendance/domain/vote/domain/VoteServiceTest.java
@@ -1,0 +1,51 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.ddd.manage_attendance.domain.vote.exception.VoteAlreadyRespondedException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class VoteServiceTest {
+
+    @Mock private VoteRepository voteRepository;
+    @Mock private VoteResponseRepository voteResponseRepository;
+    @Mock private TeamVoteAnswerRepository teamVoteAnswerRepository;
+    @Mock private TeamVoteReasonRepository teamVoteReasonRepository;
+    @Mock private FeedbackAnswerRepository feedbackAnswerRepository;
+    @InjectMocks private VoteService voteService;
+
+    @Test
+    @DisplayName("이미 응답한 멤버가 다시 제출하면 예외가 발생한다")
+    void submitResponse_whenAlreadyResponded_throws() {
+        final Vote vote = mock(Vote.class);
+        given(vote.getId()).willReturn(1L);
+        given(voteResponseRepository.existsByVoteIdAndMemberId(1L, 10L)).willReturn(true);
+
+        assertThatThrownBy(() -> voteService.submitResponse(vote, 10L, 100L, 13L, null))
+                .isInstanceOf(VoteAlreadyRespondedException.class);
+    }
+
+    @Test
+    @DisplayName("동시 제출로 유니크 제약을 위반하면 이미 참여한 것으로 처리한다")
+    void submitResponse_whenUniqueViolation_throwsAlreadyResponded() {
+        final Vote vote = mock(Vote.class);
+        given(vote.getId()).willReturn(1L);
+        given(vote.getTemplateVersion()).willReturn(1);
+        given(voteResponseRepository.existsByVoteIdAndMemberId(1L, 10L)).willReturn(false);
+        given(voteResponseRepository.save(any()))
+                .willThrow(new DataIntegrityViolationException("duplicate"));
+
+        assertThatThrownBy(() -> voteService.submitResponse(vote, 10L, 100L, 13L, null))
+                .isInstanceOf(VoteAlreadyRespondedException.class);
+    }
+}


### PR DESCRIPTION
## 개요
PR #68(투표 SDUI)·#69(조회 API) 머지 후, 코드 추적에서 발견한 **미룬 후속 작업과 누락**을 보완합니다. 스키마 변경 없음(기존 테이블/인덱스만 사용) → 신규 DDL 불필요.

## 배경 (왜)
- #68 본문이 *"운영진 실시간 집계 조회 API는 후속 PR 예정"* 이라 했으나, #69는 참여율/미참여 명단까지만 했고 **실제 결과 집계는 미구현**이었습니다. (집계용 인덱스는 `vote_feature.sql` 에 이미 존재)
- #69 본문이 *"(후속 권고) openVote 단일성 가드"* 라 적어둔 정합성 구멍이 남아 있었습니다.
- 운영진이 `voteId` 를 생성 응답 외 경로로 얻을 방법이 없었습니다.
- #69가 추가한 권한·404·집계 로직에 테스트가 없었습니다.

## 변경
### P1 — 투표 결과 집계 조회 API (운영진)
- `GET /api/votes/{voteId}/team-vote/results` — 부문별 팀 득표 순위 + 작성 사유(익명)
- `GET /api/votes/{voteId}/feedback/results` — 질문 타입별 분포(선택지/예·아니오)·텍스트, followUp 포함
- 집계는 `vote_response` 조인 JPQL 5종, OPEN/CLOSED 실시간(DRAFT 빈 결과)

### P2 — openVote 단일성 가드
- 같은 기수에 OPEN 투표가 있으면 `409 VOTE_ALREADY_OPEN`. `/active` 단일성 보장

### P3 — 운영진 목록/상세 조회
- `GET /api/votes` (목록, 최신순), `GET /api/votes/{voteId}` (상세, 편집 재개용)

### P4 — 테스트 보강 (신규 16개)
- 권한/404/단일성/참여집계 + 집계 머지 로직(0표/0응답·순위·followUp 평탄화)

### P5 — 정리
- 미사용 `VoteResponseRepository.findByVoteIdAndMemberId` 제거

## 검증
- ✅ vote 테스트 **34개 전부 통과** (기존 18 + 신규 16), `compileJava`·`spotless` 통과
- ⚠️ `ManageAttendanceApplicationTests.contextLoads` 1건 실패는 로컬 `JWT_SECRET` 미설정 환경 문제로, 변경 전(main) 상태에서도 동일 실패함을 확인 → 본 변경과 무관 (CI는 env 주입으로 통과)

## 참고 / 후속
- `team.serviceName` 데이터 적재는 별도 운영 작업으로 남음(#68에서 예고된 항목)

🤖 Generated with [Claude Code](https://claude.com/claude-code)