### PR TITLE
docs: 투표 API 프론트 연동 가이드 + VOTE_ALREADY_OPEN 400 통일

### DIFF
--- a/docs/vote-api-guide.md
+++ b/docs/vote-api-guide.md
@@ -1,0 +1,291 @@
+# 투표(Vote) API 프론트엔드 연동 가이드
+
+> 대상: 프론트엔드 개발자 · 최종 업데이트: 2026-06-10 (PR #70 기준)
+> 상세 스키마는 Swagger(`https://api.dddstudy.kr/swagger-ui/index.html`)의 **Vote** 태그 참고.
+
+## 1. 개요
+
+- **인증**: 모든 엔드포인트 JWT 필수 (`Authorization: Bearer <token>`).
+- **SDUI(Server-Driven UI)**: 서버는 질문의 "의미 타입"(`type`)과 텍스트/옵션/제약만 내려주고, **실제 렌더링은 클라이언트가 소유**합니다. 새 `type` 추가만 앱 배포가 필요하고, 텍스트·옵션·순서·제약은 서버에서 변경됩니다.
+- **두 영역**: 한 투표는 ① **팀 투표**(team-vote) + ② **참여 경험 피드백**(feedback) 두 영역을 가지며, 각각 독립 템플릿/응답입니다. 둘 중 하나만 있을 수도 있습니다(`null` 가능).
+- **상태머신**: `DRAFT`(작성중) → `OPEN`(진행중) → `CLOSED`(종료, 불가역). 멤버에게는 `OPEN`만 노출됩니다.
+- **권한**: `[운영진]` 표시 API는 운영진(MANAGER)만 호출 가능. 멤버가 호출하면 `403 MANAGER_ONLY`.
+
+## 2. 엔드포인트 한눈에 보기
+
+| 구분 | 메서드 | 경로 | 설명 | 비고 |
+|---|---|---|---|---|
+| 멤버 | GET | `/api/votes/active` | 내 기수 진행중 투표 + 내 참여 여부 | 없으면 `404` |
+| 멤버 | GET | `/api/votes/{voteId}/team-vote/template` | 팀 투표 화면 템플릿 + 팀 목록 | |
+| 멤버 | GET | `/api/votes/{voteId}/feedback/template` | 피드백 화면 템플릿 | |
+| 멤버 | POST | `/api/votes/{voteId}/responses` | 투표 제출(팀투표+피드백 원자 제출) | 1인 1응답 |
+| 멤버 | GET | `/api/votes/{voteId}/responses/me` | 내 참여 여부 | |
+| 운영진 | POST | `/api/votes` | 투표 생성(DRAFT) | |
+| 운영진 | PUT | `/api/votes/{voteId}/template` | 템플릿 수정(DRAFT만) | |
+| 운영진 | PATCH | `/api/votes/{voteId}/open` | 투표 시작 | ⚠️ `400` 추가됨 |
+| 운영진 | PATCH | `/api/votes/{voteId}/close` | 투표 종료 | |
+| 운영진 | GET | `/api/votes` | 투표 목록(최신순) | 🆕 PR #70 |
+| 운영진 | GET | `/api/votes/{voteId}` | 투표 상세(상태+양쪽 템플릿) | 🆕 PR #70 |
+| 운영진 | GET | `/api/votes/{voteId}/participation` | 참여 현황(N명/N%) | |
+| 운영진 | GET | `/api/votes/{voteId}/non-responders` | 미참여 명단 | |
+| 운영진 | GET | `/api/votes/{voteId}/team-vote/results` | 팀투표 결과 집계 | 🆕 PR #70 |
+| 운영진 | GET | `/api/votes/{voteId}/feedback/results` | 피드백 결과 집계 | 🆕 PR #70 |
+
+---
+
+## 3. 멤버 흐름
+
+### 3.1 진행중 투표 확인 — `GET /api/votes/active`
+홈 화면의 "투표(NEW)" 노출/진입 판단에 사용. **진행중 투표가 없으면 `404 VOTE_NO_ACTIVE`** 이므로 404를 "투표 없음"으로 분기하세요.
+
+```json
+// 200 OK
+{ "voteId": 1, "title": "DDD 13기 최종 투표", "alreadyResponded": false }
+```
+`alreadyResponded=true` 면 완료 화면으로 분기.
+
+### 3.2 팀 투표 템플릿 — `GET /api/votes/{voteId}/team-vote/template`
+```json
+// 200 OK
+{
+  "templateVersion": 1,
+  "status": "OPEN",
+  "template": { /* TeamVoteTemplate, 6장 참고 */ },
+  "teams": [
+    { "teamId": 101, "name": "iOS 1팀", "serviceName": "PICKFLOW", "isOwnTeam": false },
+    { "teamId": 105, "name": "iOS 5팀", "serviceName": "MOABO",    "isOwnTeam": true }
+  ]
+}
+```
+- `isOwnTeam=true` 인 팀은 **선택 불가**(본인 팀). UI에서 비활성 처리.
+- `serviceName` 은 데이터 미적재 시 `null` 일 수 있습니다.
+
+### 3.3 피드백 템플릿 — `GET /api/votes/{voteId}/feedback/template`
+```json
+// 200 OK
+{ "templateVersion": 1, "status": "OPEN", "template": { /* FeedbackTemplate, 6장 참고 */ } }
+```
+
+### 3.4 투표 제출 — `POST /api/votes/{voteId}/responses`
+팀투표 + 피드백을 **한 번에** 제출합니다. `OPEN` 상태에서만 가능, **1인 1응답(재투표 불가)**.
+
+```json
+// Request Body
+{
+  "teamVote": [
+    { "categoryId": "PLANNING", "teamIds": [101, 102], "reason": "기획 흐름이 명확했어요" }
+  ],
+  "feedback": [
+    { "questionId": "BEST_CURRICULUM", "optionIds": ["OPT_A"], "textValue": null, "boolValue": null },
+    { "questionId": "RECOMMEND",       "optionIds": null,      "textValue": null, "boolValue": true },
+    { "questionId": "FREE_FEEDBACK",   "optionIds": null,      "textValue": "좋은 경험이었습니다", "boolValue": null }
+  ]
+}
+// 201 Created (본문 없음)
+```
+**질문 타입별로 채우는 필드가 다릅니다**(타입과 안 맞는 값을 같이 보내면 `400 VOTE_ANSWER_INVALID`):
+- `MULTI_SELECT` → `optionIds`
+- `LONG_TEXT` → `textValue`
+- `BOOLEAN` → `boolValue`
+
+서버가 제약(선택 개수/본인 팀 제외/글자수/필수/모든 부문 1팀 이상)을 **재검증**합니다. 클라이언트 검증은 UX용일 뿐 신뢰 경계는 서버입니다.
+
+### 3.5 내 참여 여부 — `GET /api/votes/{voteId}/responses/me`
+```json
+// 200 OK
+{ "voteId": 1, "responded": true }
+```
+
+---
+
+## 4. 운영진 흐름
+
+### 4.1 투표 목록 🆕 — `GET /api/votes`
+본인 기수의 전체 투표를 최신순으로 반환. 관리 화면 진입점.
+```json
+// 200 OK
+[
+  { "voteId": 2, "title": "임시 투표", "status": "DRAFT", "openedAt": null, "closedAt": null, "createdDate": "2026-06-10T09:00:00" },
+  { "voteId": 1, "title": "DDD 13기 최종 투표", "status": "OPEN", "openedAt": "2026-06-10T10:00:00", "closedAt": null, "createdDate": "2026-06-09T15:00:00" }
+]
+```
+
+### 4.2 투표 상세 🆕 — `GET /api/votes/{voteId}`
+상태 + 양쪽 템플릿 전체. DRAFT 편집 재개 화면에 사용.
+```json
+// 200 OK
+{
+  "voteId": 1,
+  "title": "DDD 13기 최종 투표",
+  "status": "DRAFT",
+  "templateVersion": 2,
+  "teamVoteTemplate": { /* TeamVoteTemplate, null 가능 */ },
+  "feedbackTemplate": { /* FeedbackTemplate, null 가능 */ }
+}
+```
+
+### 4.3 참여 현황 — `GET /api/votes/{voteId}/participation`
+참여율 모집단은 **운영진 제외(MEMBER)**.
+```json
+// 200 OK
+{ "voteId": 1, "title": "DDD 13기 최종 투표", "status": "OPEN", "totalMembers": 42, "respondedMembers": 35, "participationRate": 83 }
+```
+
+### 4.4 미참여 명단 — `GET /api/votes/{voteId}/non-responders`
+```json
+// 200 OK
+{ "totalCount": 7, "members": [ { "memberId": 11, "name": "홍길동", "teamName": "iOS 1팀" } ] }
+```
+
+### 4.5 팀투표 결과 집계 🆕 — `GET /api/votes/{voteId}/team-vote/results`
+부문별 팀 득표 순위 + 작성 사유(익명). `OPEN`/`CLOSED` 모두 실시간 조회(DRAFT는 빈 결과).
+```json
+// 200 OK
+{
+  "voteId": 1,
+  "title": "DDD 13기 최종 투표",
+  "status": "CLOSED",
+  "totalResponses": 35,
+  "categories": [
+    {
+      "categoryId": "PLANNING",
+      "title": "기획 완성도",
+      "order": 1,
+      "teams": [
+        { "rank": 1, "teamId": 101, "name": "iOS 1팀", "serviceName": "PICKFLOW", "voteCount": 12 },
+        { "rank": 2, "teamId": 102, "name": "iOS 2팀", "serviceName": "MOABO",    "voteCount": 8 }
+      ],
+      "reasons": ["기획이 탄탄했어요", "사용자 흐름이 명확함"]
+    }
+  ]
+}
+```
+- `teams` 는 **득표수 내림차순**, `rank` 는 1부터. **0표 팀은 포함되지 않습니다.**
+- `reasons` 는 해당 부문에 작성된 사유 목록(작성자 식별 불가, 익명).
+
+### 4.6 피드백 결과 집계 🆕 — `GET /api/votes/{voteId}/feedback/results`
+질문 타입별로 응답 형태가 다릅니다. **사용하지 않는 필드는 `null`** 입니다. `followUp`(중첩 질문)도 평탄화되어 함께 내려옵니다.
+```json
+// 200 OK
+{
+  "voteId": 1,
+  "totalResponses": 35,
+  "questions": [
+    {
+      "questionId": "BEST_CURRICULUM", "title": "가장 좋았던 커리큘럼", "type": "MULTI_SELECT", "order": 1,
+      "options": [
+        { "optionId": "OPT_A", "label": "JPA 심화", "count": 20 },
+        { "optionId": "OPT_B", "label": "테스트 코드", "count": 0 }
+      ],
+      "trueCount": null, "falseCount": null, "textAnswers": null
+    },
+    {
+      "questionId": "RECOMMEND", "title": "다음 기수에 추천하시겠어요?", "type": "BOOLEAN", "order": 2,
+      "options": null, "trueCount": 30, "falseCount": 5, "textAnswers": null
+    },
+    {
+      "questionId": "FREE_FEEDBACK", "title": "자유 피드백", "type": "LONG_TEXT", "order": 3,
+      "options": null, "trueCount": null, "falseCount": null,
+      "textAnswers": ["좋은 경험이었습니다", "감사합니다"]
+    }
+  ]
+}
+```
+- `MULTI_SELECT` → `options[]`. **템플릿의 모든 선택지가 0 포함 분포로** 내려옵니다(차트용).
+- `BOOLEAN` → `trueCount`/`falseCount`.
+- `LONG_TEXT` → `textAnswers[]`(익명).
+
+### 4.7 생성/수정/시작/종료 (참고)
+- `POST /api/votes` — `{ generationId, title, teamVoteTemplate, feedbackTemplate }` → `201 { voteId }`
+- `PUT /api/votes/{voteId}/template` — `{ teamVoteTemplate, feedbackTemplate }` (DRAFT만, 버전 증가)
+- `PATCH /api/votes/{voteId}/open` — DRAFT → OPEN. **⚠️ 같은 기수에 이미 OPEN 투표가 있으면 `400 VOTE_ALREADY_OPEN`**
+- `PATCH /api/votes/{voteId}/close` — OPEN → CLOSED (불가역)
+
+---
+
+## 5. 에러 응답
+
+모든 에러는 동일 형식입니다.
+```json
+{ "code": "VOTE_NO_ACTIVE", "message": "진행 중인 투표가 없습니다.", "detail": null }
+```
+
+| 상태 | code | 발생 상황 |
+|---|---|---|
+| 400 | `VOTE_NOT_DRAFT` | DRAFT 아닌데 템플릿 수정 |
+| 400 | `VOTE_NOT_OPEN` | OPEN 아닌데 제출 |
+| 400 | `VOTE_INVALID_STATUS` | 잘못된 상태 전이(open/close) |
+| 400 | `VOTE_OWN_TEAM_SELECTED` | 본인 팀을 선택 |
+| 400 | `VOTE_ANSWER_INVALID` | 응답이 제약 위반(개수/글자수/필수/타입 불일치 등) |
+| 400 | `VOTE_ALREADY_RESPONDED` | 이미 참여한 멤버의 재제출 |
+| 403 | `VOTE_MANAGER_NOT_ALLOWED` | 운영진이 투표 제출 시도(운영진은 투표 대상 아님) |
+| 403 | `MANAGER_ONLY` | 멤버가 운영진 전용 API 호출 |
+| 404 | `VOTE_NOT_FOUND` | 존재하지 않는 voteId |
+| 404 | `VOTE_NO_ACTIVE` | `/active` 진행중 투표 없음 |
+| 400 | `VOTE_ALREADY_OPEN` | 🆕 같은 기수에 이미 OPEN 투표 존재(open 시) |
+
+---
+
+## 6. SDUI 템플릿 구조
+
+### 6.1 TeamVoteTemplate (팀 투표)
+```json
+{
+  "title": "팀 투표",
+  "description": "함께한 팀들을 평가해주세요",
+  "notice": "본인 팀은 선택할 수 없어요",
+  "categories": [
+    {
+      "id": "PLANNING",          // 안정 시맨틱 ID (집계 키, 라벨 바뀌어도 유지)
+      "order": 1,
+      "title": "기획 완성도",
+      "maxSelectableTeams": 2,    // 최대 선택 팀 수
+      "reasonRequired": false,    // 팀 선택 시 사유 필수 여부
+      "reasonMinLength": 0,
+      "reasonMaxLength": 500,
+      "reasonLabel": "선택 이유"
+    }
+  ]
+}
+```
+
+### 6.2 FeedbackTemplate (참여 경험 피드백)
+```json
+{
+  "title": "참여 경험 피드백",
+  "description": "솔직한 의견을 들려주세요",
+  "questions": [
+    {
+      "id": "BEST_CURRICULUM",   // 안정 시맨틱 ID (집계 키)
+      "order": 1,
+      "type": "MULTI_SELECT",     // TEAM_SELECT | MULTI_SELECT | LONG_TEXT | BOOLEAN
+      "title": "가장 좋았던 커리큘럼",
+      "helpText": "최대 2개",
+      "required": true,
+      "maxSelectableOptions": 2,  // MULTI_SELECT 최대 선택 수 (null=무제한)
+      "maxLength": null,          // LONG_TEXT 최대 글자수
+      "options": [                // MULTI_SELECT 선택지
+        { "id": "OPT_A", "label": "JPA 심화" },
+        { "id": "OPT_B", "label": "테스트 코드" }
+      ],
+      "followUp": null            // 선택적 후속 질문(같은 Question 구조, 재귀 중첩 가능)
+    }
+  ]
+}
+```
+
+### 6.3 컴포넌트 타입(VoteComponentType)
+| type | 의미 | 제출 시 채울 필드 | 결과 집계 형태 |
+|---|---|---|---|
+| `TEAM_SELECT` | 팀 선택 | (팀투표 영역 전용) | team-vote/results |
+| `MULTI_SELECT` | 다중 선택 | `optionIds` | `options[].count` |
+| `LONG_TEXT` | 장문 텍스트 | `textValue` | `textAnswers[]` |
+| `BOOLEAN` | 예/아니오 | `boolValue` | `trueCount`/`falseCount` |
+
+---
+
+## 7. 알아둘 점
+
+- **멤버용 "결과 공개" API는 아직 없습니다.** 결과 집계(`/results`)는 운영진 전용입니다. 멤버가 결과를 보는 화면이 디자인에 있다면 백엔드에 별도 요청 필요.
+- `serviceName` 은 데이터 적재 전까지 `null` 일 수 있습니다(결과/목록/팀 목록 공통).
+- 응답 시점의 소속(팀/기수)은 제출 시 스냅샷으로 고정되므로, 멤버가 이후 팀을 옮겨도 집계는 제출 당시 기준입니다.

--- a/src/main/java/com/ddd/manage_attendance/core/exception/ErrorCode.java
+++ b/src/main/java/com/ddd/manage_attendance/core/exception/ErrorCode.java
@@ -39,7 +39,7 @@ public enum ErrorCode {
     VOTE_ALREADY_RESPONDED(HttpStatus.BAD_REQUEST, "이미 투표에 참여했습니다."),
     VOTE_NO_ACTIVE(HttpStatus.NOT_FOUND, "진행 중인 투표가 없습니다."),
     VOTE_MANAGER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "운영진은 투표에 참여할 수 없습니다."),
-    VOTE_ALREADY_OPEN(HttpStatus.CONFLICT, "이미 진행 중인 투표가 있습니다."),
+    VOTE_ALREADY_OPEN(HttpStatus.BAD_REQUEST, "이미 진행 중인 투표가 있습니다."),
 
     // 데이터 관련
     DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 데이터입니다."),

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/VoteController.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/VoteController.java
@@ -86,7 +86,11 @@ public class VoteController {
     @PatchMapping("/{voteId}/open")
     @Operation(
             summary = "[운영진] 투표 시작",
-            description = "투표를 OPEN 상태로 전환합니다(템플릿 freeze).\n\n- 운영진 권한 필수\n- DRAFT 상태에서만 가능")
+            description =
+                    "투표를 OPEN 상태로 전환합니다(템플릿 freeze).\n\n"
+                            + "- 운영진 권한 필수\n"
+                            + "- DRAFT 상태에서만 가능\n"
+                            + "- 같은 기수에 진행 중(OPEN)인 투표가 있으면 400 VOTE_ALREADY_OPEN")
     @SecurityRequirement(name = "JWT")
     public void openVote(
             @AuthenticationPrincipal final Long userId, @PathVariable final Long voteId) {


### PR DESCRIPTION
## 개요
프론트엔드 연동 가이드 문서를 추가하고, 점검 중 발견한 **상태코드 정책 불일치(`VOTE_ALREADY_OPEN`)** 를 기존 정책에 맞춰 정정합니다. PR #70(투표 결과/조회 API) 후속입니다.

## 변경
### 📄 `docs/vote-api-guide.md` 신규
- 전체 엔드포인트 표 + 멤버/운영진 흐름별 **요청·응답 예시 JSON**
- 신규 4종(목록/상세/팀투표 결과/피드백 결과) 응답 스키마 상세
- SDUI 템플릿 구조(`TeamVoteTemplate`/`FeedbackTemplate`/`VoteComponentType`), 에러 코드 표, 권한 규칙

### 🔧 `VOTE_ALREADY_OPEN`: 409 → 400 (정책 통일)
프로젝트는 "이미/중복" 상황에 일관되게 `400` 을 써왔습니다.
- `AUTH_ALREADY_REGISTERED`, `ATTENDANCE_ALREADY_CHECKED`, `VOTE_ALREADY_RESPONDED` → **400**
- `VOTE_ALREADY_OPEN` 만 `409` 였음(프로젝트 내 유일) → **400 으로 통일**
- `open` 의 400 케이스를 `@Operation` description 에 명시 (400 공통 응답은 `SwaggerConfig` 로 이미 노출되므로 `@ApiResponse(409)` 는 제거)

## 참고
- 신규 엔드포인트·DTO 는 기존 `@Operation`/`@Schema` 어노테이션으로 Swagger 자동 노출됨
- 응답 envelope(공통 래퍼 없음)·권한(`validateManager`)·트랜잭션 정책은 기존과 동일함을 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)