### PR TITLE
feat: 투표 미참여 금일출석 + 생성/시작 입력검증 보강

### DIFF
--- a/src/main/java/com/ddd/manage_attendance/core/exception/ErrorCode.java
+++ b/src/main/java/com/ddd/manage_attendance/core/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     VOTE_NO_ACTIVE(HttpStatus.NOT_FOUND, "진행 중인 투표가 없습니다."),
     VOTE_MANAGER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "운영진은 투표에 참여할 수 없습니다."),
     VOTE_ALREADY_OPEN(HttpStatus.BAD_REQUEST, "이미 진행 중인 투표가 있습니다."),
+    VOTE_TEMPLATE_INVALID(HttpStatus.BAD_REQUEST, "투표 템플릿이 올바르지 않습니다."),
 
     // 데이터 관련
     DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 데이터입니다."),

--- a/src/main/java/com/ddd/manage_attendance/domain/schedule/domain/ScheduleService.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/schedule/domain/ScheduleService.java
@@ -3,6 +3,7 @@ package com.ddd.manage_attendance.domain.schedule.domain;
 import com.ddd.manage_attendance.domain.schedule.api.dto.ScheduleResponse;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +29,13 @@ public class ScheduleService {
         return scheduleRepository
                 .findByDateAndGenerationId(date, generationId)
                 .orElseThrow(NoScheduleException::new);
+    }
+
+    /** 해당 날짜의 일정을 조회한다(없을 수 있음). 일정이 없는 날을 정상 흐름으로 다룰 때 사용한다. */
+    @Transactional(readOnly = true)
+    public Optional<Schedule> findScheduleByDateAndGenerationId(
+            final LocalDate date, final Long generationId) {
+        return scheduleRepository.findByDateAndGenerationId(date, generationId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/VoteController.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/VoteController.java
@@ -18,6 +18,7 @@ import com.ddd.manage_attendance.domain.vote.domain.VoteFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -47,7 +48,7 @@ public class VoteController {
     @SecurityRequirement(name = "JWT")
     public ResponseEntity<VoteCreateResponse> createVote(
             @AuthenticationPrincipal final Long userId,
-            @RequestBody final VoteCreateRequest request) {
+            @Valid @RequestBody final VoteCreateRequest request) {
         final Long voteId = voteFacade.createVote(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(VoteCreateResponse.from(voteId));
     }

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteCreateRequest.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteCreateRequest.java
@@ -3,10 +3,17 @@ package com.ddd.manage_attendance.domain.vote.api.dto;
 import com.ddd.manage_attendance.core.sdui.FeedbackTemplate;
 import com.ddd.manage_attendance.core.sdui.TeamVoteTemplate;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Schema(title = "[투표] 투표 생성 요청 DTO")
 public record VoteCreateRequest(
-        @Schema(description = "기수 Id", example = "1") Long generationId,
-        @Schema(description = "투표 제목", example = "DDD 13기 최종 투표") String title,
+        @Schema(description = "기수 Id", example = "1") @NotNull(message = "기수 ID는 필수입니다.")
+                Long generationId,
+        @Schema(description = "투표 제목", example = "DDD 13기 최종 투표")
+                @NotBlank(message = "투표 제목은 필수입니다.")
+                @Size(max = 100, message = "투표 제목은 100자 이하여야 합니다.")
+                String title,
         @Schema(description = "팀 투표 템플릿") TeamVoteTemplate teamVoteTemplate,
         @Schema(description = "참여 경험 피드백 템플릿") FeedbackTemplate feedbackTemplate) {}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteNonRespondersResponse.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/api/dto/VoteNonRespondersResponse.java
@@ -1,5 +1,6 @@
 package com.ddd.manage_attendance.domain.vote.api.dto;
 
+import com.ddd.manage_attendance.domain.attendance.domain.AttendanceStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
@@ -12,7 +13,12 @@ public record VoteNonRespondersResponse(
     public record NonResponder(
             @Schema(description = "멤버 Id") Long memberId,
             @Schema(description = "이름", example = "홍길동") String name,
-            @Schema(description = "소속 팀명(미배정 시 null)", example = "iOS 1팀") String teamName) {}
+            @Schema(description = "소속 팀명(미배정 시 null)", example = "iOS 1팀") String teamName,
+            @Schema(
+                            description =
+                                    "금일 출석 상태 (ATTENDED/LATE/ABSENT/NONE). 금일 일정이 없거나 미체크면 NONE",
+                            example = "ATTENDED")
+                    AttendanceStatus todayAttendanceStatus) {}
 
     public static VoteNonRespondersResponse of(final List<NonResponder> members) {
         return new VoteNonRespondersResponse(members.size(), members);

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteFacade.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteFacade.java
@@ -1,8 +1,13 @@
 package com.ddd.manage_attendance.domain.vote.domain;
 
 import com.ddd.manage_attendance.core.util.TimeProvider;
+import com.ddd.manage_attendance.domain.attendance.domain.Attendance;
+import com.ddd.manage_attendance.domain.attendance.domain.AttendanceService;
+import com.ddd.manage_attendance.domain.attendance.domain.AttendanceStatus;
 import com.ddd.manage_attendance.domain.auth.domain.User;
 import com.ddd.manage_attendance.domain.auth.domain.UserService;
+import com.ddd.manage_attendance.domain.generation.domain.GenerationService;
+import com.ddd.manage_attendance.domain.schedule.domain.ScheduleService;
 import com.ddd.manage_attendance.domain.team.domain.Team;
 import com.ddd.manage_attendance.domain.team.domain.TeamService;
 import com.ddd.manage_attendance.domain.vote.api.dto.ActiveVoteResponse;
@@ -36,7 +41,11 @@ public class VoteFacade {
     private final VoteService voteService;
     private final UserService userService;
     private final TeamService teamService;
+    private final GenerationService generationService;
+    private final ScheduleService scheduleService;
+    private final AttendanceService attendanceService;
     private final VoteAnswerValidator voteAnswerValidator;
+    private final VoteTemplateValidator voteTemplateValidator;
     private final TimeProvider timeProvider;
 
     @Transactional(readOnly = true)
@@ -75,6 +84,8 @@ public class VoteFacade {
     public Long createVote(final Long userId, final VoteCreateRequest request) {
         final User manager = userService.getUser(userId);
         manager.validateManager();
+        generationService.findById(request.generationId()); // 존재하지 않는 기수면 404
+        voteTemplateValidator.validate(request.teamVoteTemplate(), request.feedbackTemplate());
         final Vote vote =
                 voteService.createDraft(
                         request.generationId(),
@@ -89,6 +100,7 @@ public class VoteFacade {
             final Long userId, final Long voteId, final VoteTemplateUpdateRequest request) {
         final User manager = userService.getUser(userId);
         manager.validateManager();
+        voteTemplateValidator.validate(request.teamVoteTemplate(), request.feedbackTemplate());
         final Vote vote = voteService.getVote(voteId);
         vote.updateTemplates(request.teamVoteTemplate(), request.feedbackTemplate());
     }
@@ -163,17 +175,44 @@ public class VoteFacade {
                 teamService.findAllByGenerationId(vote.getGenerationId()).stream()
                         .collect(Collectors.toMap(Team::getId, Team::getName));
 
+        final List<User> nonResponderUsers =
+                members.stream().filter(m -> !respondedIds.contains(m.getId())).toList();
+        final Map<Long, AttendanceStatus> todayStatusByMember =
+                resolveTodayAttendance(vote.getGenerationId(), nonResponderUsers);
+
         final List<VoteNonRespondersResponse.NonResponder> nonResponders =
-                members.stream()
-                        .filter(m -> !respondedIds.contains(m.getId()))
+                nonResponderUsers.stream()
                         .map(
                                 m ->
                                         new VoteNonRespondersResponse.NonResponder(
                                                 m.getId(),
                                                 m.getName(),
-                                                teamNameById.get(m.getTeamId())))
+                                                teamNameById.get(m.getTeamId()),
+                                                todayStatusByMember.getOrDefault(
+                                                        m.getId(), AttendanceStatus.NONE)))
                         .toList();
         return VoteNonRespondersResponse.of(nonResponders);
+    }
+
+    /** 금일 일정이 있으면 대상 멤버들의 금일 출석 상태를 매핑한다. 일정이 없으면 빈 맵(→ 호출부에서 NONE 처리). */
+    private Map<Long, AttendanceStatus> resolveTodayAttendance(
+            final Long generationId, final List<User> users) {
+        if (users.isEmpty()) {
+            return Map.of();
+        }
+        return scheduleService
+                .findScheduleByDateAndGenerationId(timeProvider.nowDate(), generationId)
+                .map(
+                        schedule -> {
+                            final List<Long> userIds = users.stream().map(User::getId).toList();
+                            return attendanceService
+                                    .findAllUsersAttendancesByScheduleId(userIds, schedule.getId())
+                                    .stream()
+                                    .collect(
+                                            Collectors.toMap(
+                                                    Attendance::getUserId, Attendance::getStatus));
+                        })
+                .orElseGet(Map::of);
     }
 
     /** [운영진] 팀 투표 결과 집계(부문별 팀 득표 + 작성 사유). 집계 행을 템플릿 부문 메타·팀 정보와 머지한다. */

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteTemplateValidator.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/domain/VoteTemplateValidator.java
@@ -1,0 +1,122 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import com.ddd.manage_attendance.core.sdui.FeedbackTemplate;
+import com.ddd.manage_attendance.core.sdui.TeamVoteTemplate;
+import com.ddd.manage_attendance.core.sdui.VoteComponentType;
+import com.ddd.manage_attendance.domain.vote.exception.VoteTemplateInvalidException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * 투표 생성/수정 시 템플릿을 "작성 시점"에 검증한다. (제출 시점의 {@link VoteAnswerValidator} 가 템플릿이 올바르다고 신뢰하기 때문)
+ *
+ * <p>여기서 막지 않으면 잘못된 템플릿이 그대로 저장·freeze 되어, 제출 단계에서야 500 또는 "응답 불가능한 투표"로 드러난다.
+ */
+@Component
+public class VoteTemplateValidator {
+
+    public void validate(
+            final TeamVoteTemplate teamVoteTemplate, final FeedbackTemplate feedbackTemplate) {
+        if (teamVoteTemplate == null && feedbackTemplate == null) {
+            throw new VoteTemplateInvalidException("팀 투표 또는 피드백 템플릿 중 하나 이상이 필요합니다.");
+        }
+        if (teamVoteTemplate != null) {
+            validateTeamVoteTemplate(teamVoteTemplate);
+        }
+        if (feedbackTemplate != null) {
+            validateFeedbackTemplate(feedbackTemplate);
+        }
+    }
+
+    private void validateTeamVoteTemplate(final TeamVoteTemplate template) {
+        final List<TeamVoteTemplate.Category> categories = template.categories();
+        if (categories == null || categories.isEmpty()) {
+            throw new VoteTemplateInvalidException("팀 투표 부문이 하나 이상 필요합니다.");
+        }
+
+        final Set<String> seenCategoryIds = new HashSet<>();
+        for (final TeamVoteTemplate.Category category : categories) {
+            if (!StringUtils.hasText(category.id())) {
+                throw new VoteTemplateInvalidException("부문 ID는 비어 있을 수 없습니다.");
+            }
+            if (!seenCategoryIds.add(category.id())) {
+                throw new VoteTemplateInvalidException("부문 ID가 중복되었습니다: " + category.id());
+            }
+            if (category.maxSelectableTeams() < 1) {
+                throw new VoteTemplateInvalidException(
+                        "부문 '%s' 의 최대 선택 팀 수는 1 이상이어야 합니다.".formatted(category.title()));
+            }
+            if (category.reasonMinLength() < 0
+                    || category.reasonMinLength() > category.reasonMaxLength()) {
+                throw new VoteTemplateInvalidException(
+                        "부문 '%s' 의 사유 글자수 범위가 올바르지 않습니다.".formatted(category.title()));
+            }
+        }
+    }
+
+    private void validateFeedbackTemplate(final FeedbackTemplate template) {
+        final List<FeedbackTemplate.Question> questions = template.questions();
+        if (questions == null || questions.isEmpty()) {
+            throw new VoteTemplateInvalidException("피드백 질문이 하나 이상 필요합니다.");
+        }
+
+        final Set<String> seenQuestionIds = new HashSet<>();
+        for (final FeedbackTemplate.Question question : questions) {
+            validateQuestion(question, seenQuestionIds);
+        }
+    }
+
+    /** follow-up 까지 재귀로 검증한다. JSON 은 트리라 순환이 없으므로 재귀는 항상 종료된다. */
+    private void validateQuestion(
+            final FeedbackTemplate.Question question, final Set<String> seenQuestionIds) {
+        if (!StringUtils.hasText(question.id())) {
+            throw new VoteTemplateInvalidException("질문 ID는 비어 있을 수 없습니다.");
+        }
+        if (!seenQuestionIds.add(question.id())) {
+            throw new VoteTemplateInvalidException("질문 ID가 중복되었습니다: " + question.id());
+        }
+        if (question.type() == null) {
+            throw new VoteTemplateInvalidException(
+                    "질문 '%s' 의 타입이 비어 있습니다.".formatted(question.title()));
+        }
+        if (question.type() == VoteComponentType.TEAM_SELECT) {
+            throw new VoteTemplateInvalidException("피드백 질문에 허용되지 않는 타입입니다: " + question.title());
+        }
+        if (question.type() == VoteComponentType.MULTI_SELECT) {
+            validateOptions(question);
+        }
+        if (question.maxLength() != null && question.maxLength() < 1) {
+            throw new VoteTemplateInvalidException(
+                    "질문 '%s' 의 최대 글자수는 1 이상이어야 합니다.".formatted(question.title()));
+        }
+        if (question.followUp() != null) {
+            validateQuestion(question.followUp(), seenQuestionIds);
+        }
+    }
+
+    private void validateOptions(final FeedbackTemplate.Question question) {
+        final List<FeedbackTemplate.Option> options = question.options();
+        if (options == null || options.isEmpty()) {
+            throw new VoteTemplateInvalidException(
+                    "다중 선택 질문 '%s' 은 선택지가 하나 이상 필요합니다.".formatted(question.title()));
+        }
+        final Set<String> seenOptionIds = new HashSet<>();
+        for (final FeedbackTemplate.Option option : options) {
+            if (!StringUtils.hasText(option.id())) {
+                throw new VoteTemplateInvalidException(
+                        "질문 '%s' 의 선택지 ID는 비어 있을 수 없습니다.".formatted(question.title()));
+            }
+            if (!seenOptionIds.add(option.id())) {
+                throw new VoteTemplateInvalidException(
+                        "질문 '%s' 의 선택지 ID가 중복되었습니다: %s".formatted(question.title(), option.id()));
+            }
+        }
+        if (question.maxSelectableOptions() != null && question.maxSelectableOptions() < 1) {
+            throw new VoteTemplateInvalidException(
+                    "질문 '%s' 의 최대 선택 개수는 1 이상이어야 합니다.".formatted(question.title()));
+        }
+    }
+}

--- a/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteTemplateInvalidException.java
+++ b/src/main/java/com/ddd/manage_attendance/domain/vote/exception/VoteTemplateInvalidException.java
@@ -1,0 +1,12 @@
+package com.ddd.manage_attendance.domain.vote.exception;
+
+import com.ddd.manage_attendance.core.exception.BaseException;
+import com.ddd.manage_attendance.core.exception.ErrorCode;
+
+/** 생성/수정 시 투표 템플릿이 구조 제약(필수/중복/범위 등)을 위반한 경우. 구체 사유를 커스텀 메시지로 전달한다. */
+public class VoteTemplateInvalidException extends BaseException {
+
+    public VoteTemplateInvalidException(final String message) {
+        super(ErrorCode.VOTE_TEMPLATE_INVALID, message);
+    }
+}

--- a/src/test/java/com/ddd/manage_attendance/domain/vote/domain/VoteFacadeTest.java
+++ b/src/test/java/com/ddd/manage_attendance/domain/vote/domain/VoteFacadeTest.java
@@ -9,8 +9,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.ddd.manage_attendance.core.util.TimeProvider;
+import com.ddd.manage_attendance.domain.attendance.domain.AttendanceService;
 import com.ddd.manage_attendance.domain.auth.domain.User;
 import com.ddd.manage_attendance.domain.auth.domain.UserService;
+import com.ddd.manage_attendance.domain.generation.domain.GenerationService;
+import com.ddd.manage_attendance.domain.schedule.domain.ScheduleService;
 import com.ddd.manage_attendance.domain.team.domain.Team;
 import com.ddd.manage_attendance.domain.team.domain.TeamService;
 import com.ddd.manage_attendance.domain.vote.api.dto.ActiveVoteResponse;
@@ -37,7 +40,11 @@ class VoteFacadeTest {
     @Mock private VoteService voteService;
     @Mock private UserService userService;
     @Mock private TeamService teamService;
+    @Mock private GenerationService generationService;
+    @Mock private ScheduleService scheduleService;
+    @Mock private AttendanceService attendanceService;
     @Mock private VoteAnswerValidator voteAnswerValidator;
+    @Mock private VoteTemplateValidator voteTemplateValidator;
     @Mock private TimeProvider timeProvider;
     @InjectMocks private VoteFacade voteFacade;
 

--- a/src/test/java/com/ddd/manage_attendance/domain/vote/domain/VoteTemplateValidatorTest.java
+++ b/src/test/java/com/ddd/manage_attendance/domain/vote/domain/VoteTemplateValidatorTest.java
@@ -1,0 +1,149 @@
+package com.ddd.manage_attendance.domain.vote.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ddd.manage_attendance.core.sdui.FeedbackTemplate;
+import com.ddd.manage_attendance.core.sdui.TeamVoteTemplate;
+import com.ddd.manage_attendance.core.sdui.VoteComponentType;
+import com.ddd.manage_attendance.domain.vote.exception.VoteTemplateInvalidException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class VoteTemplateValidatorTest {
+
+    private final VoteTemplateValidator validator = new VoteTemplateValidator();
+
+    private TeamVoteTemplate.Category category(
+            final String id, final int maxTeams, final int minLen, final int maxLen) {
+        return new TeamVoteTemplate.Category(id, 1, "부문", maxTeams, true, minLen, maxLen, "사유");
+    }
+
+    private FeedbackTemplate.Question question(
+            final String id,
+            final VoteComponentType type,
+            final List<FeedbackTemplate.Option> opts) {
+        return new FeedbackTemplate.Question(id, 1, type, "질문", null, true, null, 300, opts, null);
+    }
+
+    private TeamVoteTemplate teamTemplate(final List<TeamVoteTemplate.Category> categories) {
+        return new TeamVoteTemplate("팀 투표", "설명", "공지", categories);
+    }
+
+    @Test
+    @DisplayName("정상 템플릿은 통과한다")
+    void valid_passes() {
+        final TeamVoteTemplate team = teamTemplate(List.of(category("PLANNING", 2, 5, 300)));
+        final FeedbackTemplate feedback =
+                new FeedbackTemplate(
+                        "피드백",
+                        "설명",
+                        List.of(
+                                question(
+                                        "BEST",
+                                        VoteComponentType.MULTI_SELECT,
+                                        List.of(new FeedbackTemplate.Option("OT", "OT")))));
+
+        assertThatCode(() -> validator.validate(team, feedback)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("두 템플릿이 모두 없으면 예외가 발생한다")
+    void bothNull_throws() {
+        assertThatThrownBy(() -> validator.validate(null, null))
+                .isInstanceOf(VoteTemplateInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("부문 ID가 중복되면 예외가 발생한다")
+    void duplicateCategoryId_throws() {
+        final TeamVoteTemplate team =
+                teamTemplate(List.of(category("DUP", 2, 5, 300), category("DUP", 2, 5, 300)));
+
+        assertThatThrownBy(() -> validator.validate(team, null))
+                .isInstanceOf(VoteTemplateInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("최대 선택 팀 수가 1 미만이면 예외가 발생한다")
+    void nonPositiveMaxTeams_throws() {
+        final TeamVoteTemplate team = teamTemplate(List.of(category("PLANNING", 0, 5, 300)));
+
+        assertThatThrownBy(() -> validator.validate(team, null))
+                .isInstanceOf(VoteTemplateInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("사유 최소 글자수가 최대보다 크면 예외가 발생한다")
+    void reasonMinGreaterThanMax_throws() {
+        final TeamVoteTemplate team = teamTemplate(List.of(category("PLANNING", 2, 300, 5)));
+
+        assertThatThrownBy(() -> validator.validate(team, null))
+                .isInstanceOf(VoteTemplateInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("부문이 비어 있으면 예외가 발생한다")
+    void emptyCategories_throws() {
+        assertThatThrownBy(() -> validator.validate(teamTemplate(List.of()), null))
+                .isInstanceOf(VoteTemplateInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("피드백 질문 타입이 TEAM_SELECT 이면 예외가 발생한다")
+    void teamSelectFeedbackType_throws() {
+        final FeedbackTemplate feedback =
+                new FeedbackTemplate(
+                        "피드백", "설명", List.of(question("Q", VoteComponentType.TEAM_SELECT, null)));
+
+        assertThatThrownBy(() -> validator.validate(null, feedback))
+                .isInstanceOf(VoteTemplateInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("다중 선택 질문에 선택지가 없으면 예외가 발생한다")
+    void multiSelectWithoutOptions_throws() {
+        final FeedbackTemplate feedback =
+                new FeedbackTemplate(
+                        "피드백",
+                        "설명",
+                        List.of(question("Q", VoteComponentType.MULTI_SELECT, List.of())));
+
+        assertThatThrownBy(() -> validator.validate(null, feedback))
+                .isInstanceOf(VoteTemplateInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("질문 ID가 (follow-up 포함) 중복되면 예외가 발생한다")
+    void duplicateQuestionId_throws() {
+        final FeedbackTemplate.Question followUp =
+                new FeedbackTemplate.Question(
+                        "DUP",
+                        2,
+                        VoteComponentType.LONG_TEXT,
+                        "후속",
+                        null,
+                        false,
+                        null,
+                        300,
+                        null,
+                        null);
+        final FeedbackTemplate.Question top =
+                new FeedbackTemplate.Question(
+                        "DUP",
+                        1,
+                        VoteComponentType.LONG_TEXT,
+                        "최상위",
+                        null,
+                        false,
+                        null,
+                        300,
+                        null,
+                        followUp);
+        final FeedbackTemplate feedback = new FeedbackTemplate("피드백", "설명", List.of(top));
+
+        assertThatThrownBy(() -> validator.validate(null, feedback))
+                .isInstanceOf(VoteTemplateInvalidException.class);
+    }
+}


### PR DESCRIPTION
PR #69(머지 완료) 이후 추가된 투표 기능 보강 2건입니다.

## 1) 미참여 명단에 금일 출석 현황 추가 (`bc646f9`)
재귀 검증으로 발견: 운영진 **미참여명단 모달** 디자인 명세에 "금일 출석 현황(출석/지각/결석)"이 있는데 API에 누락돼 있었음.
- `GET /api/votes/{voteId}/non-responders` 응답에 `todayAttendanceStatus`(ATTENDED/LATE/ABSENT/NONE) 추가
- 금일 일정(generationId+오늘) 조회 후 미참여 멤버 출석 매핑, 일정/출석행 없으면 NONE
- `ScheduleService.findScheduleByDateAndGenerationId`(Optional) 추가

## 2) 생성/시작 입력 검증 보강 (`d36545b`)
omc·superpowers 리뷰로 발견한 '조용히 통과하던' 입력 갭을 작성 시점에 차단.
- **createVote**: 존재하지 않는 `generationId` 검증(`generationService.findById` → 404). 기존엔 없는 기수로도 고아 투표 생성됐음.
- **VoteCreateRequest**: `@Valid` + `@NotNull(generationId)`/`@NotBlank·@Size(100)(title)` → blank/null 제목이 500 대신 400.
- **VoteTemplateValidator(신규)**: 부문/질문/옵션 ID 중복·공백, maxSelectableTeams<1, reasonMin>Max, 빈 categories/questions, type null/TEAM_SELECT, MULTI_SELECT 빈 옵션 차단 (이전엔 제출 시점 500 또는 '응답 불가능한 투표'로 드러나던 것).
- **openVote**: 기수당 OPEN 투표 1개 보장(`VOTE_ALREADY_OPEN`).
- ErrorCode `VOTE_TEMPLATE_INVALID`/`VOTE_ALREADY_OPEN` + 예외 2종 + 단위테스트.

## 참고 (의도된 동작 — 변경 안 함)
- 운영진은 **전체 기수 글로벌 권한** 확인됨 → 기수 스코프 검증 미적용.

## 검증
- 단위테스트 통과(VoteTemplateValidatorTest 9케이스 포함)
- 런타임(H2): 없는기수 404 / 빈제목 400 / 잘못된템플릿 400 VOTE_TEMPLATE_INVALID / 중복open 400 VOTE_ALREADY_OPEN / non-responders todayAttendanceStatus(ATTENDED·NONE) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)